### PR TITLE
Migrate recipes to structured front matter, fix schema and a11y

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -4,17 +4,12 @@ date: {{ .Date }}
 draft: false
 tags: []
 categories: []
+prepTime: 0
+cookTime: 0
+servings: "2 servings"
+ingredients:
+  - ""
+steps:
+  - ""
 ---
 
-
-
-<div class="recipe" id="recipe">
-Prep time: X minutes
-
-Cooking time: X minutes
-
-- [ ]
-
-1. 
-
-</div>

--- a/assets/style.sass
+++ b/assets/style.sass
@@ -135,7 +135,7 @@ nav.pagination
     flex-wrap: wrap
     grid-gap: .3rem
     grid-template-columns: 1fr 1fr 1fr
-    span.article
+    a.article
       position: relative
       text-align: center
       padding: 10px 10px 15px 10px
@@ -146,14 +146,11 @@ nav.pagination
       display: flex
       flex-direction: column
       justify-content: space-between
+      color: inherit
+      text-decoration: none
       // min-height: 26rem
       &:hover
-        a
-          color: $link
-      div.bottom-link
-        position: relative
-        text-align: right
-        margin-top: 1rem
+        color: $link
       div.cover_image
         width: 100%
         aspect-ratio: 4 / 3
@@ -206,7 +203,7 @@ div.round-teasers
       transition: color .2s ease-in-out
 div.recent-posts
   border-top: 1px solid silver
-  div.article
+  a.article
     display: flex
     flex-direction: column
     padding: 1rem
@@ -214,10 +211,11 @@ div.recent-posts
     gap: .5rem
     cursor: pointer
     position: relative
+    color: inherit
+    text-decoration: none
     &:hover
       background: #e6dfcd
-      a
-        color: $link
+      color: $link
     h2
       margin: 0
       font-size: 1.35rem
@@ -414,14 +412,17 @@ div.recipe
       margin-top: 0
   h4
     margin-top: .6rem
-  ul 
+  ul
     margin: .6rem 0 0 0
     padding: 0 0 0 .6rem
     list-style-type: none
     li
       margin: .3rem 0
-      input
-        accent-color: #2a2926
+    li.ingredient-section
+      font-weight: 600
+      margin-top: .8rem
+      list-style-type: none
+      color: #2a2926
   ol
     margin-top: 0
     li
@@ -600,7 +601,7 @@ div#statusDiv
         div.wrapper
           width: 75%
           margin: auto
-  div.recent-posts div.article h2
+  div.recent-posts a.article h2
     font-size: 1.2rem
 
 @media screen and (max-width: 1400px)
@@ -673,7 +674,7 @@ div#statusDiv
       flex-direction: column
       display: flex
       gap: 1rem
-      span.article
+      a.article
         width: 93%
         margin: auto
         div.cover_image
@@ -705,7 +706,7 @@ div#statusDiv
     p
       img
         width: 75%
-  div.recent-posts div.article h2
+  div.recent-posts a.article h2
     font-size: revert
   .masonry-gallery
     column-count: 1

--- a/content/posts/oatmeal/berry/index.md
+++ b/content/posts/oatmeal/berry/index.md
@@ -4,27 +4,22 @@ date: 2023-03-23T22:22:00+01:00
 draft: false
 tags: ["stove-cooked", "berries"]
 categories: ["Oatmeal"]
+prepTime: 4
+cookTime: 2
+servings: "1 serving"
+ingredients:
+  - "1 cup rolled oats"
+  - "1.5 cups soy milk"
+  - "1/2 cup blueberries"
+  - "1/2 cup strawberries"
+  - "1 tablespoon shredded coconut"
+  - "1 tablespoon maple syrup"
+steps:
+  - "Cook the oats in the soy milk until it is thick and creamy."
+  - "Put into a bowl, add the blueberries and strawberries."
+  - "Drizzle with maple syrup and top with shredded coconut."
 ---
 
 In this oatmeal the blueberries are cooked for a bit, and then they are added at the end. This helps
 out a lot with the goopy texture of the oatmeal. Good balance, also the strawberries lift it up a bit.
 Topped with some shredded coconut and maple syrup.
-
-<div class="recipe" id="recipe">
-Prep time: 4 minutes
-
-Cooking time: 2 minutes
-
-### Ingredients for 1 serving
-- [ ] 1 cup rolled oats
-- [ ] 1.5 cups soy milk
-- [ ] 1/2 cup blueberries
-- [ ] 1/2 cup strawberries
-- [ ] 1 tablespoon shredded coconut
-- [ ] 1 tablespoon maple syrup
-
-### Steps
-1. Cook the oats in the soy milk until it is thick and creamy.
-2. Put into a bowl, add the blueberries and strawberries.
-3. Drizzle with maple syrup and top with shredded coconut.
-</div>

--- a/content/posts/oatmeal/kiwi/index.md
+++ b/content/posts/oatmeal/kiwi/index.md
@@ -4,25 +4,20 @@ date: 2023-04-06T12:22:00+01:00
 draft: false
 tags: ["microwave", "fruit"]
 categories: ["Oatmeal"]
+prepTime: 4
+cookTime: 2
+servings: "1 serving"
+ingredients:
+  - "1 cup rolled oats"
+  - "1 large banana"
+  - "1.5 cups almond milk"
+  - "2 kiwi"
+  - "1 cup peanuts"
+steps:
+  - "Mash the banana in a bowl and add oats."
+  - "Pour over milk and mix. The oats should be liberally submerged."
+  - "Cook in the microwave for 2 minutes."
+  - "Decorate with kiwi cut in half and peanuts."
 ---
 
 This is an unusual flavor combination. Kiwi is actually a very decent oatmeal topping, as any fruit. I think the sourness is quite important to balance out the texture of the oatmeal. Almond milk is one of the better ones for oatmeal.
-
-<div class="recipe" id="recipe">
-Prep time: 4 minutes
-
-Cooking time: 2 minutes
-
-### Ingredients for 1 serving
-- [ ] 1 cup rolled oats
-- [ ] 1 large banana
-- [ ] 1.5 cups almond milk
-- [ ] 2 kiwi
-- [ ] 1 cup peanuts
-
-### Steps
-1. Mash the banana in a bowl and add oats.
-2. Pour over milk and mix. The oats should be liberally submerged.
-3. Cook in the microwave for 2 minutes. 
-4. Decorate with kiwi cut in half and peanuts.
-</div>

--- a/content/posts/savory/blistered tomato gnocchi/index.md
+++ b/content/posts/savory/blistered tomato gnocchi/index.md
@@ -4,33 +4,27 @@ date: 2025-07-06T10:00:00+01:00
 draft: false
 tags: ["lunch", "gnocchi", "italian", "pasta"]
 categories: ["Savory"]
+prepTime: 15
+cookTime: 25
+servings: "2 servings"
+ingredients:
+  - "300g potatoes, peeled"
+  - "160g flour"
+  - "40g olive oil"
+  - "300g oyster mushrooms"
+  - "10 medium size tomatoes"
+  - "40g cashew nuts, soaked"
+  - "2 garlic cloves"
+  - "10g chopped parsley"
+steps:
+  - "Boil the potatoes in salted water until soft, about 20 minutes. Drain and let them cool down a bit. Grate them finely or pass through a ricer. Add the flour and 20g of olive oil, pinch of salt and mix well. Knead the dough for 90 seconds or so — it should be soft and not sticky. If it is too sticky, add a bit more flour. Do not over-knead it, otherwise the gnocchi will be tough."
+  - "Divide the dough into 2 parts and roll each into a long tube, about 1.5cm in diameter. Cut the tube into 2cm pieces and roll each piece over a fork to create the gnocchi shape. Set aside."
+  - "In a large pan, heat some olive oil and add the oyster mushrooms. Cook on medium heat for about 5 minutes until they are golden brown."
+  - "In another pan, heat the remaining olive oil and add chopped garlic. Cook for a minute until slightly browned. Add in the halved tomatoes and cook stirring occasionally, gently, for about 10 minutes until they blister and soften."
+  - "Bring a large pot of salted water to a boil. Add the gnocchi and cook until they float to the surface, about 2-3 minutes."
+  - "In a blender, add the soaked cashews and a splash of water. Blend until smooth and creamy, adding more water if needed to achieve a sauce-like consistency. Add to the pan with the tomatoes and stir well. Season with salt and pepper to taste."
+  - "Add the gnocchi including some of the cooking water and mushrooms to the sauce. Gently mix everything together. Cook for another minute to heat through, adding more water if needed to loosen the sauce."
+  - "Serve hot, garnished with chopped parsley."
 ---
 
 I resisted the urge to buy ready-made gnocchi and it is definitely a much simpler process than I expected. They are very soft, fluffy and paired with the creamy sauce and hit of sour from the tomatoes they make a very balanced dish.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 25 minutes
-
-### Ingredients for 2 servings
-- [ ] 300g potatoes, peeled
-- [ ] 160g flour
-- [ ] 40g olive oil
-- [ ] 300g oyster mushrooms
-- [ ] 10 medium size tomatoes
-- [ ] 40g cashew nuts, soaked
-- [ ] 2 garlic cloves
-- [ ] 10g chopped parsley
-
-### Steps
-1. Boil the potatoes in salted water until soft, about 20 minutes. Drain and let them cool down a bit. Grate them finely or pass through a ricer. Add the flour and 20g of olive oil, pinch of salt and mix well. Knead the dough for 90 seconds or so, it should be soft and not sticky. If it is too sticky, add a bit more flour. Do not over-knead it, otherwise the gnocchi will be tough.
-2. Divide the dough into 2 parts and roll each into a long tube, about 1.5cm in diameter. Cut the tube into 2cm pieces and roll each piece over a fork to create the gnocchi shape. Set aside. You can adjust the size of the gnocchi to your liking.
-3. In a large pan, heat some olive oil and add the oyster mushrooms. Cook on medium heat for about 5 minutes until they are golden brown.
-4. In another pan, heat the remaining olive oil and add chopped garlic. Cook for a minute until slightly browned. Add in the halved tomatoes and cook stirring occasionally, gently, for about 10 minutes until they blister and soften.
-5. Bring a large pot of salted water to a boil. Add the gnocchi and cook until they float to the surface, about 2-3 minutes.
-6. In a blender, add the soaked cashews and a splash of water. Blend until smooth and creamy, adding more water if needed to achieve a sauce-like consistency. Add to the pan with the tomatoes and stir well. Season with salt and pepper to taste.
-7. Add the gnocchi including some of the cooking water and mushrooms to the sauce. Gently mix everything together. Cook for another minute to heat through, adding more water if needed to loosen the sauce.
-8. Serve hot, garnished with chopped parsley.
-
-</div>

--- a/content/posts/savory/bolognese/index.md
+++ b/content/posts/savory/bolognese/index.md
@@ -4,42 +4,36 @@ date: 2023-03-05T14:12:00+01:00
 draft: false
 tags: ["lunch", "red-lentils", "italian", "pasta"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 25
+servings: "2 servings"
+ingredients:
+  - "1 tablespoon olive oil"
+  - "1 small onion"
+  - "1/2 stalk celery"
+  - "1 medium carrot"
+  - "2 cloves of garlic"
+  - "1/2 cup red lentils"
+  - "1/2 cup of water"
+  - "1/2 can diced tomatoes"
+  - "2 tablespoons nutritional yeast"
+  - "2 tablespoons mixed herbs (oregano, thyme, rosemary)"
+  - "300g pasta of your choice"
+  - "salt and pepper to taste"
+steps:
+  - "Start by finely chopping the onion and celery."
+  - "Grate the carrot on the fine side of the grater."
+  - "Chop the garlic into small pieces."
+  - "Heat the oil in a pan over medium heat."
+  - "Add the onion, celery and carrot and cook until the onion is translucent."
+  - "Add the garlic and cook for another minute."
+  - "Add the lentils and stir until coated in the oil."
+  - "Toast the lentils for a minute or two, then deglaze with water and stir until it is absorbed."
+  - "Add the tomatoes, nutritional yeast, mixed herbs and salt/pepper and cook for 10-15 minutes until the lentils are soft."
+  - "Cook the pasta according to the instructions on the package."
+  - "Mix 3/4 of the pasta with the sauce and serve the rest on top."
 ---
 
 Today I have for you a red lentil bolognese sauce. It is my own approximation of the traditional recipe. It is made from red lentils,
 because they have more of a subtle flavor, and they cook really quickly. In this recipe I had used bucatini, but any long pasta
 such as spaghettoni or spahgetti will do. You could top it with some vegan parmesan if you like.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 25 minutes
-
-### Ingredients for 2 servings
-- [ ] 1 tablespoon olive oil
-- [ ] 1 small onion
-- [ ] 1/2 stalk celery
-- [ ] 1 medium carrot
-- [ ] 2 cloves of garlic
-- [ ] 1/2 cup red lentils
-- [ ] 1/2 cup of water
-- [ ] 1/2 can diced tomatoes
-- [ ] 2 tablespoons nutritional yeast
-- [ ] 2 tablespoons mixed herbs (oregano, thyme, rosemary)
-- [ ] 300g pasta of your choice
-- [ ] salt and pepper to taste
-
-### Steps
-1. Start by finely chopping the onion and celery.
-2. Grate the carrot on the fine side of the grater.
-3. Chop the garlic into small pieces.
-4. Heat the oil in a pan over medium heat.
-5. Add the onion, celery and carrot and cook until the onion is translucent.
-6. Add the garlic and cook for another minute.
-7. Add the lentils and stir until coated in the oil.
-8. Toast the lentils for a minute or two, then deglaze with water and stir until it is absorbed.
-9. Add the tomatoes, nutritional yeast, mixed herbs and salt/pepper and cook for 10-15 minutes until the lentils are soft.
-10. Cook the pasta according to the instructions on the package.
-11. Mix 3/4 of the pasta with the sauce and serve the rest on top.
-
-</div>

--- a/content/posts/savory/broccoli-soup/index.md
+++ b/content/posts/savory/broccoli-soup/index.md
@@ -4,32 +4,26 @@ date: 2023-01-20T14:11:41+01:00
 draft: false
 tags: ["gluten-free", "soup", "greens", "broccoli"]
 categories: ["Savory"]
+prepTime: 3
+cookTime: 10
+servings: "5 servings"
+ingredients:
+  - "1 head of broccoli (1kg)"
+  - "2 cloves of garlic"
+  - "1 tablespoon mustard seeds"
+  - "small white onion, diced"
+  - "2 tablespoons coconut milk"
+  - "1 tablespoon of coconut or olive oil"
+  - "salt and pepper to taste"
+steps:
+  - "No need to chop the onion and garlic too finely as we will end by blending the soup. Do not overcook the broccoli — it is about the healthiest thing you can eat, but not if you destroy all the nutrients."
+  - "Heat the oil in the pan and sauté the onions until translucent together with the mustard seeds."
+  - "Add the garlic and get some color on both."
+  - "Add your broccoli in large chunks and pour over boiling water to stop the onions from burning. The broccoli should be covered by a bit of water — this will depend on how thick you like your soup."
+  - "Cook until the broccoli has softened, but not completely soft."
+  - "Add salt, pepper and coconut milk (possibly other spices like paprika or nutmeg) and blend with an immersion blender until smooth."
 ---
 
 I love broccoli, but sometimes it is left around for a bit longer than ideal and starts to break apart. It is impossible to use it then for anything unless you love random bits of broccoli everywhere.
 
 Therefore, the best thing to do to it is blend it up! This recipe is for a simple soup made of broccoli and coconut milk.
-
-<div class="recipe" id="recipe">
-Prep time: 3 minutes
-
-Cooking time: 10 minutes
-
-### Ingredients for 5 servings
-- [ ] 1 head of broccoli (1kg)
-- [ ] 2 cloves of garlic
-- [ ] 1 tablespoon mustard seeds
-- [ ] small white onion, diced
-- [ ] 2 tablespoons coconut milk
-- [ ] 1 tablespoon of coconut or olive oil
-- [ ] salt and pepper to taste
-
-### Steps
-No need to chop the onion and garlic too finely as we are will end by blending the soup. Do not overcook the broccoli, it is about the healthiest thing you can eat but not if you destroy all the nutrients.
-1. Heat the oil in the pan and sauté the onions until translucent together with the mustard seeds.
-2. Add the garlic and get some color on both.
-3. Add your broccoli in large chunks and pour over boiling water to stop the onions from burning. The broccoli should be covered by a bit of water. This will depends on how think you like your soup.
-4. Cook until the broccoli has softened, but not completely soft.
-5. Add salt, pepper and coconut milk (possible other spices (paprika, nutmeg)) and blend with an immersion blender until smooth.
-
-</div>

--- a/content/posts/savory/broccoli-walnut-pasta/index.md
+++ b/content/posts/savory/broccoli-walnut-pasta/index.md
@@ -4,36 +4,30 @@ date: 2024-09-07T00:00:00Z
 draft: false
 tags: ["pasta", "broccoli", "nuts"]
 categories: ["Savory"]
+prepTime: 10
+cookTime: 30
+servings: "1 tray"
+ingredients:
+  - "200g dried pasta"
+  - "2 cups broccoli florets"
+  - "1 medium carrot"
+  - "1 small red pepper"
+  - "juice of 1/2 lemon"
+  - "70g walnuts"
+  - "1/2 cup vegetable stock"
+  - "1/2 cup fresh parsley"
+  - "1/2 cup fresh oregano"
+  - "3 cloves of garlic"
+  - "salt and pepper to taste"
+  - "1 cup cherry tomatoes"
+steps:
+  - "Boil water in a large pot and begin to cook the pasta according to the package instructions."
+  - "After about 5 minutes, add the broccoli florets to the pot together with the carrot, cut into small pieces."
+  - "In your blender, combine the lemon juice, walnuts, vegetable stock, parsley, oregano, garlic, salt and pepper. Blend until smooth."
+  - "Once the pasta is cooked, drain it and return it to the pot. Add the sauce and mix well."
+  - "Add the red pepper, cut into small pieces, and the cherry tomatoes, cut in half. Mix well and serve hot or cold."
 ---
 
 I've enjoyed this pasta salad largely thanks to the walnuts, which I haven't used with pasta before. When blended with the herbs, it tastes kind of like a pesto, I couldn't taste the walnuts that much. Perfect for some spare broccoli!
 
 You can sub the oregano for cilantro or any other herb you like :)
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 30 minutes
-
-### Ingredients for 1 tray
-- [ ] 200g dried pasta
-- [ ] 2 cups broccoli florets
-- [ ] 1 medium carrot
-- [ ] 1 small red pepper
-- [ ] juice of 1/2 lemon
-- [ ] 70g walnuts
-- [ ] 1/2 cup vegetable stock
-- [ ] 1/2 cup fresh parsley
-- [ ] 1/2 cup fresh oregano
-- [ ] 3 cloves of garlic
-- [ ] salt and pepper to taste
-- [ ] 1 cup cherry tomatoes
-
-
-### Steps
-1. Boil water in a large pot and begin to cook the pasta according to the package instructions.
-2. After about 5 minutes, add the broccoli florets to the pot together with the carrot, cut into small pieces.
-3. In your blender, combine the lemon juice, walnuts, vegetable stock, parsley, cilantro, garlic, chili paste, salt and pepper. Blend until smooth.
-4. Once the pasta is cooked, drain it and return it to the pot. Add the sauce and mix well.
-5. Add the red pepper, cut into small pieces, and the cherry tomatoes, cut in half. Mix well and serve hot or cold.
-</div>

--- a/content/posts/savory/buckwheat-squash-soup/index.md
+++ b/content/posts/savory/buckwheat-squash-soup/index.md
@@ -4,37 +4,31 @@ date: 2024-01-07T11:00:00+01:00
 draft: false
 tags: ["gluten-free", "soup", "broccoli", "buckwheat", "simple"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 30
+servings: "4 servings"
+ingredients:
+  - "1/2 butternut squash"
+  - "1/4 broccoli in small florets"
+  - "2 small onions"
+  - "2 cloves of garlic"
+  - "1 tablespoon of mustard seeds"
+  - "1 tablespoon of olive oil"
+  - "1/2 cup buckwheat"
+  - "1/2 cup cashews"
+  - "salt and pepper to taste"
+steps:
+  - "Blend your soaked cashews with 1 cup of water until smooth. Set aside."
+  - "Heat the oil in a large pot."
+  - "Add the mustard seeds and fry until they start to pop."
+  - "Add the onions and garlic and fry until translucent."
+  - "Add the squash and fry for a few minutes, then add your buckwheat."
+  - "Add enough water to cover the squash and bring to a boil."
+  - "Cook until the squash becomes soft, but not mushy."
+  - "Add the broccoli and cook for a few more minutes."
+  - "Add the cashew cream and season with salt and pepper."
 ---
 
 Winter is the ideal season for soup. Full of squash and buckwheat, this is quite a healthy one too.
 
 Feel free to alter the greens here, kale or spinach would work well too.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 30 minutes
-
-### Ingredients for 4 servings
-- [ ] 1/2 butternut squash
-- [ ] 1/4 broccoli in small florets
-- [ ] 2 small onions
-- [ ] 2 cloves of garlic
-- [ ] 1 tablespoon of mustard seeds
-- [ ] 1 tablespoon of olive oil
-- [ ] 1/2 cup buckwheat
-- [ ] 1/2 cup cashews
-- [ ] salt and pepper to taste
-
-### Steps
-Blend you soaked cashews with 1 cup of water until smooth. Set aside.
-1. Heat the oil in a large pot
-2. Add the mustard seeds and fry until they start to pop
-3. Add the onions and garlic and fry until translucent
-4. Add the squash and fry for a few minutes. Then add your buckwheat
-5. Add enough water to cover the squash and bring to a boil
-6. Cook until the squash becomes soft, but not mushy
-7. Add the broccoli and cook for a few more minutes
-8. Add the cashew cream and season with salt and pepper
-
-</div>

--- a/content/posts/savory/cauliflower-curry/index.md
+++ b/content/posts/savory/cauliflower-curry/index.md
@@ -4,44 +4,39 @@ date: 2023-03-31T11:00:41+01:00
 draft: false
 tags: ["lunch", "gluten-free", "cauliflower", "red-lentils"]
 categories: ["Savory"]
+prepTime: 15
+cookTime: 60
+servings: "5 servings"
+ingredients:
+  - "1 head medium cauliflower, cut into florets"
+  - "1 large sweet potato, cut into cubes"
+  - "1 onion, chopped"
+  - "4 cloves garlic, minced"
+  - "1 cup red lentils"
+  - "2 tablespoons coconut oil"
+  - "1 tablespoon curry powder"
+  - "1 tablespoon red curry paste"
+  - "1/2 can coconut milk"
+  - "1/2 can chopped tomatoes"
+  - "2 cups water"
+  - "1 teaspoon salt"
+  - "1 teaspoon pepper"
+  - "2 cups white rice"
+  - "## Optionally add"
+  - "1/2 cup frozen peas"
+  - "1/2 cup cilantro, chopped"
+steps:
+  - "Cook your rice according to your preferences."
+  - "Heat the coconut oil in a large pot over medium heat."
+  - "Add the onion and cook until the onion is translucent."
+  - "Add the garlic and cook for another minute."
+  - "Add the cauliflower and sweet potato and get some color on them."
+  - "Add your lentils, tomatoes and water and bring to a boil."
+  - "Cook until the lentils and cauliflower are soft."
+  - "Add the coconut milk, curry powder, curry paste, salt and pepper and stir until combined."
+  - "Optionally add the cilantro and cook for another minute."
+  - "Serve with rice with peas."
 ---
 
 I make this recipe quite regularly. It's a great way to use up leftover cauliflower, and it's also very filling. I usually make a big batch and eat it for lunch for a few days.
 You can experiment with different spices and vegetables. I've tried it with carrots in place of the sweet potato and it was also very good.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 1 hour
-
-### Ingredients for 5 servings
-- [ ] 1 head medium cauliflower, cut into florets
-- [ ] 1 large sweet potato, cut into cubes
-- [ ] 1 onion, chopped
-- [ ] 4 cloves garlic, minced
-- [ ] 1 cup red lentils
-- [ ] 2 tablespoons coconut oil
-- [ ] 1 tablespoon curry powder
-- [ ] 1 tablespoon red curry paste
-- [ ] 1/2 can coconut milk
-- [ ] 1/2 can chopped tomatoes
-- [ ] 2 cups water
-- [ ] 1 teaspoon salt
-- [ ] 1 teaspoon pepper
-- [ ] 2 cups white rice
-
-#### Optionally add
-- [ ] 1/2 cup frozen peas
-- [ ] 1/2 cup cilantro, chopped
-### Steps
-Cook your rice according to your preferences.
-1. Heat the coconut oil in a large pot over medium heat.
-2. Add the onion and cook until the onion is translucent.
-3. Add the garlic and cook for another minute.
-4. Add the cauliflower and sweet potato and get some color on them.
-5. Add your lentils, tomatoes and water and bring to a boil.
-6. Cook until the lentils and cauliflower are soft.
-7. Add the coconut milk, curry powder, curry paste, salt and pepper and stir until combined.
-8. Optionally add the cilantro and cook for another minute.
-9. Serve with rice with peas.
-</div>

--- a/content/posts/savory/cauliflower-red-lentil-curry/index.md
+++ b/content/posts/savory/cauliflower-red-lentil-curry/index.md
@@ -4,41 +4,34 @@ date: 2024-07-10T12:00:00+01:00
 draft: false
 tags: ["gluten-free", "legumes", "curry", "cauliflower", "simple"]
 categories: ["Savory"]
+prepTime: 10
+cookTime: 30
+servings: "2 servings"
+ingredients:
+  - "250g split red lentils"
+  - "quarter of a normal sized cauliflower, roughly chopped"
+  - "1 onion, chopped"
+  - "3 cloves garlic, minced"
+  - "about the same amount of ginger, minced"
+  - "1 large carrot"
+  - "1 tablespoon coconut oil"
+  - "1 tablespoon yellow curry mix"
+  - "1 can coconut milk"
+  - "1 can chopped tomatoes"
+  - "2 cups water"
+  - "1 teaspoon salt"
+  - "1 teaspoon pepper"
+  - "1 cup white rice, cooked"
+steps:
+  - "Rinse the lentils and set aside."
+  - "Heat the coconut oil in a large pot over medium heat."
+  - "Add the onion and cook until the onion is translucent."
+  - "Add the garlic and ginger and cook for another minute."
+  - "Add the cauliflower and carrot and get some color on them."
+  - "Add your lentils, tomatoes and water and bring to a boil. Keep stirring to prevent sticking. Add water as needed."
+  - "Cook until the lentils and cauliflower are soft."
+  - "Add the coconut milk, curry mix, salt and pepper and stir until combined."
+  - "Serve with rice."
 ---
 
 Long time no post! To remedy this, only a very yellow recipe for my very yellow site can do. On today's menu is a yellow curry with red lentils and cauliflower (both are important!). I've posted a similar one before, but this one is a bit more well rounded. To yellow!
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 30 minutes
-
-### Ingredients for 2 servings
-- [ ] 250g split red lentils
-- [ ] quarter of a normal sized cauliflower, roughly chopped
-- [ ] 1 onion, chopped
-- [ ] 3 cloves garlic, minced
-- [ ] about the same amount of ginger, minced
-- [ ] 1 large carrot
-- [ ] 1 tablespoon coconut oil
-- [ ] 1 tablespoon yellow curry mix
-- [ ] 1 can coconut milk
-- [ ] 1 can chopped tomatoes
-- [ ] 2 cups water
-- [ ] 1 teaspoon salt
-- [ ] 1 teaspoon pepper
-- [ ] 1 cup white rice, cooked
-
-
-### Steps
-1. Rinse the lentils and set aside.
-2. Heat the coconut oil in a large pot over medium heat.
-3. Add the onion and cook until the onion is translucent.
-4. Add the garlic and ginger and cook for another minute.
-5. Add the cauliflower and carrot and get some color on them.
-6. Add your lentils, tomatoes and water and bring to a boil. Keep stirring to prevent sticking. Add water as needed.
-7. Cook until the lentils and cauliflower are soft.
-8. Add the coconut milk, curry mix, salt and pepper and stir until combined.
-9. Serve with rice.
-
-</div>

--- a/content/posts/savory/cherry-tomato-pasta/index.md
+++ b/content/posts/savory/cherry-tomato-pasta/index.md
@@ -4,27 +4,21 @@ date: 2023-07-12T14:00:00+01:00
 draft: false
 tags: ["lunch", "gluten-free", "pasta", "simple"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 25
+servings: "2 servings"
+ingredients:
+  - "250g dry pasta"
+  - "3 cloves of garlic"
+  - "1 teaspoon olive oil"
+  - "10 cherry tomatoes"
+  - "greens to your liking (I used chard)"
+steps:
+  - "Heat the oil in a large pan over medium heat."
+  - "Add the garlic and cook until the garlic is translucent."
+  - "In a separate pot, cook the pasta according to the instructions on the package."
+  - "Add in the tomatoes and stir around. Then when they start to burst, add in a splash of the pasta water and your greens. Put aside when the greens are wilted."
+  - "When the pasta is done, add it to the pan and stir around."
 ---
 
 Very simple recipe today for some pasta that looks blander than it was. Sometimes, though, you just want to eat something that is not too complicated and that you can make in 30 minutes. This is one of those recipes. I grew the chard myself, so i was very happy to be able to use it in a recipe.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 25 minutes
-
-### Ingredients for 2 servings
-- [ ] 250g dry pasta
-- [ ] 3 cloves of garlic
-- [ ] 1 teaspoon olive oil
-- [ ] 10 cherry tomatoes
-- [ ] greens to your liking (I used chard)
-
-### Steps
-1. Heat the oil in a large pan over medium heat.
-2. Add the garlic and cook until the garlic is translucent.
-3. In a separate pot, cook the pasta according to the instructions on the package.
-4. Add in the tomatoes and stir around. Then when they start to burst, add in a splash of the pasta water and your greens. Put aside when the greens are wilted.
-5. When the pasta is done, add it to the pan and stir around.
-
-</div>

--- a/content/posts/savory/chickpea-curry/index.md
+++ b/content/posts/savory/chickpea-curry/index.md
@@ -4,41 +4,34 @@ date: 2025-06-12T12:00:00+01:00
 draft: false
 tags: ["lunch", "gluten-free", "chickpeas", "legumes"]
 categories: ["Savory"]
+prepTime: 7
+cookTime: 20
+servings: "4 servings"
+ingredients:
+  - "1 can chickpeas (drained)"
+  - "1 onion"
+  - "a healthy piece of ginger (say a few cm long)"
+  - "3 garlic cloves"
+  - "1/2 can tomatoes"
+  - "1 can coconut milk"
+  - "200g fresh spinach (or more if you like)"
+  - "1 tbsp coconut oil"
+  - "1 tbsp curry powder"
+  - "salt and pepper to taste"
+  - "## Optionally add"
+  - "sprinkle of chili seeds"
+  - "juice of 1/2 lime"
+steps:
+  - "Heat the vegetable oil in a large pan over medium heat."
+  - "Add the diced onion and sauté until translucent, about 4 minutes."
+  - "Stir in the minced garlic and grated ginger, cooking for another 2 minutes until fragrant."
+  - "Add the curry powder and cook for another minute, stirring constantly."
+  - "Pour in the canned tomatoes and coconut milk, stirring to combine."
+  - "Add the chickpeas and bring the mixture to a boil."
+  - "Reduce the heat and let it simmer for about 10 minutes."
+  - "Stir in the fresh spinach and cook until wilted, about 2-3 minutes."
+  - "Season with salt and pepper to taste."
+  - "Serve with rice or naan bread, and optionally sprinkle with chili seeds and a squeeze of lime juice."
 ---
 
 If you think I'm just clutching at straws with this recipe, you are indeed correct. So to feel like I am not wasting money on a domain name, here is a very fancy curry recipe :)
-
-<div class="recipe" id="recipe">
-Prep time: 7 minutes
-
-Cooking time: 20 minutes
-
-### Ingredients for 4 servings
-- [ ] 1 can chickpeas (without the water duh)
-- [ ] 1 onion
-- [ ] a healthy piece of ginger (say a few cm long)
-- [ ] 3 garlic cloves
-- [ ] 1/2 can tomatoes
-- [ ] 1 can coconut milk
-- [ ] 200g fresh spinach (or more if you like)
-- [ ] 1 tbsp coconut oil
-- [ ] 1 tbsp curry powder
-- [ ] salt and pepper to taste
-
-#### Optionally add
-- [ ] sprinkle of chili seeds
-- [ ] juice of 1/2 lime
-
-### Steps
-1. Heat the vegetable oil in a large pan over medium heat.
-2. Add the diced onion and sauté until translucent, about 4 minutes.
-3. Stir in the minced garlic and grated ginger, cooking for another 2 minutes until fragrant.
-4. Add the curry powder and cook for another minute, stirring constantly.
-5. Pour in the canned tomatoes and coconut milk, stirring to combine.
-6. Add the chickpeas and bring the mixture to a boil.
-7. Reduce the heat and let it simmer for about 10 minutes.
-8. Stir in the fresh spinach and cook until wilted, about 2-3 minutes.
-9. Season with salt and pepper to taste.
-10. Serve with rice or naan bread, and optionally sprinkle with chili seeds and a squeeze of lime juice.
-
-</div>

--- a/content/posts/savory/chili/index.md
+++ b/content/posts/savory/chili/index.md
@@ -4,55 +4,48 @@ date: 2023-01-22T14:11:41+01:00
 draft: false
 tags: ["lunch", "gluten-free", "beans", "legumes", "spicy", "pressure-cooker"]
 categories: ["Savory"]
+prepTime: 15
+cookTime: 60
+servings: "10 servings"
+ingredients:
+  - "1 cup kidney beans"
+  - "1 cup mungo beans"
+  - "1/2 cup black beans"
+  - "1/2 cup others (black eye peas, pinto beans, ...)"
+  - "1 large red onion"
+  - "4 cloves of garlic"
+  - "1 large green or yellow pepper"
+  - "1 large sweet potato"
+  - "1 can of tomatoes"
+  - "2 tablespoons of tomato paste"
+  - "1 tablespoon of chili powder"
+  - "1 tablespoon of smoked paprika"
+  - "1 tablespoon of regular paprika"
+  - "1 tablespoon of mustard seeds"
+  - "1.5 tablespoon of nutritional yeast"
+  - "salt and pepper to taste"
+  - "juice of 1/2 lime"
+  - "1 piece of chocolate"
+  - "2 tablespoons olive oil"
+  - "3 cups boiling water"
+  - "## Optionally add"
+  - "variable amount of spinach leaves"
+steps:
+  - "Soak the beans overnight or for at least 8 hours. Drain and rinse the beans. This recipe is meant for a pressure cooker — you may use a regular pot, but it will take longer."
+  - "Heat the oil in a large pot over medium heat."
+  - "Add the mustard seeds and onion and cook until the onion is translucent."
+  - "Add the sweet potato (large cubes) and cook until it gets some color on it."
+  - "Add the garlic and dry spices."
+  - "Add in the tomatoes and tomato paste and stir until combined."
+  - "Add the beans and peppers (in 2cm squares) and stir until they are coated in the mixture, then add your chocolate piece."
+  - "Pour over the water until everything is covered by 3 centimeters or so of water."
+  - "Cover the pressure cooker and cook on low, enough to maintain a steady boil, for 1 hour."
+  - "Add the lime juice and nutritional yeast and season with salt and pepper to taste."
+  - "Serve with rice (ideally with peas) or flatbread."
 ---
 
 Chili is something I take very seriously. There are quite a few recipes on the internet,
-but naturally - mine is the best. It has been refined and perfected over 
+but naturally — mine is the best. It has been refined and perfected over
 many years, and I am very proud of it.
 
 It is a great dish to make in bulk and freeze for later. It keeps in the fridge for about 5 days max.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 1 hour
-
-### Ingredients for 10 servings
-- [ ] 1 cup kidney beans
-- [ ] 1 cup mungo beans
-- [ ] 1/2 cup black beans
-- [ ] 1/2 cup others (black eye peas, pinto beans, ...)
-- [ ] 1 large red onion
-- [ ] 4 cloves of garlic
-- [ ] 1 large green or yellow pepper
-- [ ] 1 large sweet potato
-- [ ] 1 can of tomatoes
-- [ ] 2 tablespoons of tomato paste
-- [ ] 1 tablespoon of chili powder
-- [ ] 1 tablespoon of smoked paprika
-- [ ] 1 tablespoon of regular paprika
-- [ ] 1 tablespoon of mustard seeds
-- [ ] 1.5 tablespoon of nutritional yeast
-- [ ] salt and pepper to taste
-- [ ] juice of 1/2 lime
-- [ ] 1 piece of chocolate
-- [ ] 2 tablespoons olive oil
-- [ ] 3 cups boiling water
-#### Optionally add
-- [ ] variable amount of spinach leaves
-
-### Steps
-Soak the beans overnight or for at least 8 hours. Drain and rinse the beans. This recipe is meant 
-for a pressure cooker. You may use a regular pot, but it will take longer.
-1. Heat the oil in a large pot over medium heat.
-2. Add the mustard seeds and onion and cook until the onion is translucent.
-3. Add the sweet potato (large cubes) and cook until it gets some color on it.
-4. Add the garlic and dry spices.
-5. Add in the tomatoes and tomato paste and stir until combined.
-6. Add the beans and peppers (in 2cm squares) and stir until they are coated in the mixture, then add your chocolate piece.
-7. Pour over the water until everything is covered by 3 centimeters or so of water.
-8. Cover the slow cooker and cook on low, enough to maintain a steady boil, for 1 hour. 
-9. Add the lime juice and nutritional yeast and season with salt and pepper to taste.
-10. Serve with rice (ideally with peas) or flatbread.
-
-</div>

--- a/content/posts/savory/farfalle-soup/index.md
+++ b/content/posts/savory/farfalle-soup/index.md
@@ -4,56 +4,50 @@ date: 2023-12-28T11:00:00+01:00
 draft: false
 tags: ["lunch", "italian", "pasta", "soup"]
 categories: ["Savory"]
+prepTime: 15
+cookTime: 45
+servings: "4 servings"
+ingredients:
+  - "500g cooked pasta"
+  - "1 large red onion, finely chopped"
+  - "2 cloves of garlic, minced"
+  - "1 small celery stalk, finely chopped"
+  - "2 medium carrots, in small cubes"
+  - "2 tbsp olive oil"
+  - "1 can of tomatoes"
+  - "100g textured soy protein"
+  - "1 tbsp nutritional yeast"
+  - "1 tbsp mixed dry Italian herbs (oregano, basil, thyme)"
+  - "handful of fresh parsley, chopped"
+  - "750 ml water, or vegetable broth (I used a stock cube)"
+  - "3 tablespoons cashew ricotta"
+  - "salt and pepper to taste"
+steps:
+  - "Start by finely chopping the onion, garlic, celery and carrots."
+  - "Heat the olive oil in a large pot and add the chopped vegetables. Fry for 5 minutes until color develops."
+  - "Add the tomatoes, textured soy protein, herbs, salt, pepper and water. Bring to a boil and let simmer for 30 minutes until the carrots are soft."
+  - "Add the cooked pasta, cashew ricotta and nutritional yeast and let simmer for another 5-10 minutes."
+  - "Serve with more cashew ricotta and fresh herbs (I used parsley)."
 ---
 
 Pasta in soup will always be a favorite of mine. Especially if I have any leftovers. This recipe is for a kind of lasagna-like soup using a lot of tomatoes, cashew ricotta and farfalle pasta.
 
-<div class="recipe" id="recipe">
-<h3 class="title">Farfalle soup</h3>
-
-Prep time: 15 minutes
-
-Cooking time: 45 minutes
-
-### Ingredients for 4 servings
-- [ ] 500g cooked pasta
-- [ ] 1 large red onion, finely chopped
-- [ ] 2 cloves of garlic, minced
-- [ ] 1 small celery stalk, finely chopped
-- [ ] 2 medium carrots, in small cubes
-- [ ] 2 tbsp olive oil
-- [ ] 1 can of tomatoes
-- [ ] 100g textured soy protein
-- [ ] 1 tbsp nutritional yeast
-- [ ] 1 tbsp mixed dry italian herbs (oregano, basil, thyme)
-- [ ] handful of fresh parsley, chopped
-- [ ] 750 ml water, or vegetable broth (I used a stock cube)
-- [ ] 3 tablespoons cashew ricotta
-- [ ] salt and pepper to taste
-
-### Steps
-1. Start by finely chopping the onion, garlic, celery and carrots.
-2. Heat the olive oil in a large pot and add the chopped vegetables. Fry for 5 minutes until color develops.
-3. Add the tomatoes, textured soy protein, herbs, salt, pepper and water. Bring to a boil and let simmer for 30 minutes until the carrots are soft.
-4. Add the cooked pasta, cashew ricotta and nutritional yeast and let simmer for another 5-10 minutes.
-5. Serve with more cashew ricotta and fresh herbs (I used parsley).
-
-</div>
-
-<div class="recipe" id="recipe">
-<h3 class="title">Cashew ricotta</h3>
+<div class="recipe">
+<h3>Cashew ricotta</h3>
 
 Prep time: 5 minutes
 
-### Ingredients for 8 servings
-- [ ] 1/2 cup cashews
-- [ ] 1/2 cup water
-- [ ] 1/2 tbsp nutritional yeast
-- [ ] 1 tsp salt
-- [ ] 1/2 tbsp lemon juice
-- [ ] 1 garlic clove
+Ingredients for 8 servings:
 
-### Steps
+- 1/2 cup cashews
+- 1/2 cup water
+- 1/2 tbsp nutritional yeast
+- 1 tsp salt
+- 1/2 tbsp lemon juice
+- 1 garlic clove
+
+Steps:
+
 1. Soak the cashews in water for at least 4 hours.
 2. Drain the cashews and add them to a blender with the rest of the ingredients.
 3. Blend until smooth.

--- a/content/posts/savory/filling-pasta/index.md
+++ b/content/posts/savory/filling-pasta/index.md
@@ -4,33 +4,28 @@ date: 2023-01-19T14:00:00+01:00
 draft: false
 tags: ["lunch", "gluten-free", "pasta", "simple"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 20
+servings: "1 serving"
+ingredients:
+  - "250g dry pasta"
+  - "1 block of tempeh"
+  - "1/2 onion (red is better)"
+  - "1 clove of garlic"
+  - "1 can of chopped tomatoes"
+  - "1 medium sweet potato"
+  - "1 teaspoon olive oil"
+  - "a healthy amount of spinach"
+  - "salt and pepper to taste"
+steps:
+  - "Heat the oil in a large pan over medium heat."
+  - "Add the onion and cook until the onion is translucent."
+  - "Add in the tomatoes and stir around."
+  - "Add in your sweet potato and pasta and stir around."
+  - "Put the lid on and cook until the pasta is done."
+  - "Add in the spinach and stir around until it wilts."
+  - "Serve with some nutritional yeast on top."
 ---
 
 Not sure how to describe this recipe. I usually make this because of how incredibly filling it is. It's also very
 simple to make. Italians look away!
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 5 minutes
-
-### Ingredients for 1 serving
-- [ ] 250g dry pasta
-- [ ] 1 block of tempeh
-- [ ] 1/2 onion (red is better)
-- [ ] 1 clove of garlic
-- [ ] can of chopped tomatoes
-- [ ] 1 medium sweet potato
-- [ ] 1 teaspoon olive oil
-- [ ] a healthy amount of spinach
-- [ ] salt and pepper to taste
-
-### Steps
-1. Heat the oil in a large pan over medium heat.
-2. Add the onion and cook until the onion is translucent.
-3. Add in the tomatoes and stir around.
-4. Add in your sweet potato and pasta and stir around.
-5. Put the lid on and cook until the pasta is done.
-6. Add in the spinach and stir around until it wilts.
-7. Serve with some nutritional yeast on top.
-</div>

--- a/content/posts/savory/green-soup/index.md
+++ b/content/posts/savory/green-soup/index.md
@@ -4,6 +4,32 @@ date: 2023-12-31T12:00:00+01:00
 draft: false
 tags: ["gluten-free", "broccoli", "soup", "simple", "spinach"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 20
+servings: "2 servings"
+ingredients:
+  - "1 head of broccoli"
+  - "60g of spinach"
+  - "1 onion"
+  - "1 clove of garlic"
+  - "1 tbsp olive oil"
+  - "1 block tofu"
+  - "1 tablespoon smoked paprika"
+  - "1 teaspoon ginger powder"
+  - "1 teaspoon salt"
+  - "3/2 tablespoons coconut cream"
+  - "500ml water"
+  - "handful of pumpkin seeds"
+  - "1 stalk green onion"
+  - "## Optionally add"
+  - "chili powder to taste"
+steps:
+  - "Cook your tofu in the air fryer with some salt, olive oil and paprika, or bake in the oven or pan fry it."
+  - "Heat the oil in a pan over medium high heat and add your chopped onion and garlic. Cook until the onion is translucent."
+  - "Add the broccoli (including the stem), ginger and water. Bring to a boil and simmer until the broccoli is tender."
+  - "Add the spinach and cook until wilted."
+  - "Add the paprika, salt and coconut cream. Blend until smooth."
+  - "Serve with the tofu and pumpkin seeds. Optionally add some more smoked paprika and green onion."
 ---
 
 This delicious creamy soup is quite green. Did I mention it's green? Don't get discouraged by the color, it's really tasty and easy to make. I served it with some air fried tofu and pumpkin seeds.
@@ -11,37 +37,3 @@ This delicious creamy soup is quite green. Did I mention it's green? Don't get d
 Don't throw away the broccoli stem! It's perfectly edible and tastes great in this soup. Just peel the outer layer, remove the hard bottom and chop it up.
 
 Don't cook the spinach for too long, it will lose its color and taste. Just add it at the end and cook until wilted.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 20 minutes
-
-### Ingredients for 2 servings
-- [ ] 1 head of broccoli
-- [ ] 60g of spinach
-- [ ] 1 onion
-- [ ] 1 clove of garlic
-- [ ] 1 tbsp olive oil
-- [ ] 1 block tofu
-- [ ] 1 tablespoon smoked paprika
-- [ ] 1 teaspoon ginger powder
-- [ ] 1 teaspoon salt
-- [ ] 3/2 tablespoons coconut cream
-- [ ] 500ml water
-- [ ] handful of pumpkin seeds
-- [ ] 1 stalk green onion
-
-#### Optionally add
-- [ ] chili powder to taste
-
-### Steps
-I cooked my tofu in the air fryer with some salt, olive oil and paprika. You can also bake it in the oven or pan fry it.
-
-1. Heat the oil in a pan over medium high heat and add your chopped onion and garlic. Cook until the onion is translucent.
-2. Add the broccoli (including the stem), ginger and water. Bring to a boil and simmer for until the broccoli is tender.
-3. Add the spinach and cook until wilted.
-4. Add the paprika, salt and coconut cream. Blend until smooth.
-5. Serve with the tofu and pumpkin seeds. Optionally add some more smoked paprika and green onion.
-
-</div>

--- a/content/posts/savory/hearthy-soup/index.md
+++ b/content/posts/savory/hearthy-soup/index.md
@@ -4,43 +4,36 @@ date: 2023-05-13T00:00:00+01:00
 draft: false
 tags: ["lunch", "gluten-free", "sweet-potato", "pumpkin"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 15
+servings: "2 servings"
+ingredients:
+  - "1 tablespoon coconut oil"
+  - "1 medium red onion"
+  - "1 medium sweet potato"
+  - "3 medium carrots"
+  - "1/4 small pumpkin (I used butternut)"
+  - "1/2 tablespoon paprika"
+  - "1 tablespoon thyme"
+  - "3 cloves of garlic"
+  - "piece of ginger, grated"
+  - "juice of 1/2 small lemon"
+  - "## Optionally add"
+  - "1/2 orange, including a piece of the peel"
+steps:
+  - "Heat the oil in a large pot over medium heat."
+  - "Finely chop the onion and add it to the pot."
+  - "Peel and chop the sweet potato, carrots and pumpkin into small pieces."
+  - "Add the vegetables to the pot and stir until coated in the oil."
+  - "Cook for a few minutes, stirring occasionally until the vegetables start to soften a little bit."
+  - "Add the paprika, thyme, garlic and ginger and cook for another minute."
+  - "Add enough water to cover the vegetables and bring to a boil."
+  - "Cook until the vegetables are soft."
+  - "Add the lemon juice, or orange and stir."
+  - "Blend the soup until smooth. You can use a blender, or an immersion blender."
+  - "Serve with some bread. Optionally garnish with pumpkin seeds, or some fresh herbs."
 ---
 
-Today I have for you an absolutely delicous soup made from all the beautiful orange vegetables that I could get my hands on. It is perfect for a cold winter day, or a light dinner. Just hearthy enough, not to kill your energy for the rest of the day. It is a wonderful mix of sweet and savory flavors, with a hint of ginger and lemon.
+Today I have for you an absolutely delicious soup made from all the beautiful orange vegetables that I could get my hands on. It is perfect for a cold winter day, or a light dinner. Just hearthy enough, not to kill your energy for the rest of the day. It is a wonderful mix of sweet and savory flavors, with a hint of ginger and lemon.
 
 If you want to make it a bit more special, you can add half an orange and a piece of the peel. This will give it a bit more of a citrusy flavor. I have tried it both ways and I like them both.
-
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 15 minutes
-
-### Ingredients for 2 servings
-- [ ] 1 tablespoon coconut oil
-- [ ] 1 medium red onion
-- [ ] 1 medium sweet potato
-- [ ] 3 medium carrots
-- [ ] 1/4 small pumpkin (I used butternut)
-- [ ] 1/2 tablespoon paprika
-- [ ] 1 tablespoon thyme
-- [ ] 3 cloves of garlic
-- [ ] piece of ginger, grated
-- [ ] juice of 1/2 small lemon
-#### Optionally add
-- [ ] 1/2 orange, including a piece of the peel
-
-### Steps
-1. Heat the oil in a large pot over medium heat.
-2. Finely chop the onion and add it to the pot.
-3. Peel and chop the sweet potato, carrots and pumpkin into small pieces.
-4. Add the vegetables to the pot and stir until coated in the oil.
-5. Cook for a few minutes, stirring occasionally until the vegetables start to soften a little bit.
-6. Add the paprika, thyme, garlic and ginger and cook for another minute.
-7. Add enough water to cover the vegetables and bring to a boil.
-8. Cook until the vegetables are soft.
-9. Add the lemon juice, or orange and stir.
-10. Blend the soup until smooth. You can use a blender, or an immersion blender.
-11. Serve with some bread. Optionally garnish with pumpkin seeds, or some fresh herbs.
-
-</div>

--- a/content/posts/savory/lasagna/index.md
+++ b/content/posts/savory/lasagna/index.md
@@ -4,11 +4,49 @@ date: 2024-01-22T12:00:00+01:00
 draft: false
 tags: ["pasta", "italian", "zucchini", "mushrooms", "lunch"]
 categories: ["Savory"]
+prepTime: 30
+cookTime: 60
+servings: "1 tray (~8 servings)"
+ingredients:
+  - "## For the ragu"
+  - "1 large red onion, chopped"
+  - "3 cloves of garlic, minced"
+  - "1 medium zucchini, ~1cm cubes"
+  - "1/2 medium eggplant, ~1cm cubes"
+  - "1 cup finely chopped mushrooms (I've used champignon)"
+  - "1 large stick of celery, finely chopped"
+  - "2 tbsp olive oil"
+  - "2 cans of chopped tomatoes"
+  - "1 tbsp tomato paste"
+  - "200g vegan mince (I've used a soy-based one)"
+  - "1 tbsp mixed Italian herbs"
+  - "## For the béchamel"
+  - "90g vegan butter"
+  - "50g flour"
+  - "0.75l soy milk"
+  - "1 onion, peeled and cut into 8"
+  - "1 bay leaf"
+  - "1 tsp salt"
+  - "1/2 tsp nutmeg"
+  - "100g grated vegan cheese"
+  - "2 tbsp nutritional yeast"
+  - "## Pasta"
+  - "1/2 pack of lasagna sheets"
+steps:
+  - "In a medium pot, add your milk and boil it with the onion, bay leaf, salt and nutmeg. Once it boils, turn off the heat and let it sit for 10 minutes. Strain the milk and set aside."
+  - "In a large pot, add the olive oil and sauté the onion and celery. Once they are soft, add the garlic and sauté for 1 minute."
+  - "Add the zucchini, eggplant and mushrooms and sauté for 5 minutes until the vegetables start to soften. Watch out for the bottom of the pot — you don't want it to burn."
+  - "Add the tomato paste and the canned tomatoes. Add the Italian herbs and the vegan mince and stir well. Pour in a cup of water and let it simmer for at least 15 minutes. Add water as needed, but the ragu should be thick by the end."
+  - "In a medium pot on medium heat, melt the butter and add the flour. Stir well with a silicone spatula until it becomes a paste. Gradually add the milk and whisk rapidly until it thickens. Add the nutritional yeast and the grated cheese and stir well. Set aside."
+  - "Preheat the oven to 180°C."
+  - "In a large tray, add a layer of ragu, then a layer of béchamel, then a layer of lasagna sheets. Repeat until you run out of ingredients. The top layer should be béchamel and ideally a bit thicker to be completely white."
+  - "Bake for 45 minutes, or until the top starts to brown. Let it cool for 10 minutes before serving."
+  - "For a clean cut, let it cool completely and then reheat it in the oven for 10 minutes."
 ---
 
-Oh but lasagna, what a beautiful dish. There surely isn't anyone who doesn't love good hot slice! I must say though, it disappears very quickly. This is an adaptation of the exquisite [avantgardevegan](https://www.gazoakleychef.com/recipes/lasagne/) recipe, but with more mushrooms and smaller measurements. Turned out great!
+Oh but lasagna, what a beautiful dish. There surely isn't anyone who doesn't love a good hot slice! I must say though, it disappears very quickly. This is an adaptation of the exquisite [avantgardevegan](https://www.gazoakleychef.com/recipes/lasagne/) recipe, but with more mushrooms and smaller measurements. Turned out great!
 
-I made the ragu a day in advance and apart from making this dish a bit less daunting, it also allowed the flavors to mingle a bit better I think. The bechamel is quite quick to make, but you could also infuse the milk in advance.
+I made the ragu a day in advance and apart from making this dish a bit less daunting, it also allowed the flavors to mingle a bit better I think. The béchamel is quite quick to make, but you could also infuse the milk in advance.
 
 <div class="image-split">
 
@@ -16,50 +54,4 @@ I made the ragu a day in advance and apart from making this dish a bit less daun
 ![slice](side.png)
 
 <span class="caption">Slice - Side view</span>
-</div>
-
-<div class="recipe" id="recipe">
-Prep time: 30 minutes
-
-Cooking time: 1 hour
-
-### Ingredients for 1 tray (~8 servings)
-#### For the ragu
-- [ ] 1 large red onion, chopped
-- [ ] 3 cloves of garlic, minced
-- [ ] 1 medium zuccini, ~1cm cubes
-- [ ] 1/2 medium eggplant, ~1cm cubes
-- [ ] 1 cup finely chopped mushrooms (I've used champignon)
-- [ ] 1 large stick of celery, finely chopped
-- [ ] 2 tbsp olive oil
-- [ ] 2 cans of chopped tomatoes
-- [ ] 1 tbsp tomato paste
-- [ ] 200g vegan mince (I've used a soy-based one)
-- [ ] 1 tbsp mixed italian herbs
-
-#### For the bechamel
-- [ ] 90g vegan butter
-- [ ] 50g flour
-- [ ] 0.75l soy milk
-- [ ] 1 onion, peeled and cut into 8
-- [ ] 1 bay leaf
-- [ ] 1 tsp salt
-- [ ] 1/2 tsp nutmeg
-- [ ] 100g grated vegan cheese (I've used a soy-based one)
-- [ ] 2 tbsp nutritional yeast
-
-#### Pasta
-- [ ] 1/2 pack of lasagna sheets
-
-### Steps
-1. In a medium pot, add your milk and boil it with the onion, bay leaf, salt and nutmeg. Once it boils, turn off the heat and let it sit for 10 minutes. Strain the milk and set aside.
-2. In a large pot, add the olive oil and saute the onion and celery. Once they are soft, add the garlic and saute for 1 minute.
-3. Add the zucchini, eggplant and mushrooms and saute for 5 minutes until the vegetables start to soften. Watch out for the bottom of the pot, you don't want it to burn.
-4. Add the tomato paste and the canned tomatoes. Add the italian herbs and the vegan mince and stir well. Pour in a cup of water and let it simmer for at least 15 minutes. Add water as needed, but the ragu should be thick by the end.
-5. In a medium pot on medium heat, melt the butter and add the flour. Stir well with a silicone spatula until it becomes a paste. Gradually add the milk and whisk rapidly until it thickens. Add the nutritional yeast and the grated cheese and stir well. Set aside.
-6. Preheat the oven to 180C.
-7. In a large tray, add a layer of ragu, then a layer of bechamel, then a layer of lasagna sheets. Repeat until you run out of ingredients. The top layer should be bechamel and ideally a bit thicker to be completely white.
-8. Bake for 45 minutes, or until the top starts to brown. Let it cool for 10 minutes before serving.
-9. For a clean cut, let it cool completely and then reheat it in the oven for 10 minutes.
-
 </div>

--- a/content/posts/savory/lentil-dhal/index.md
+++ b/content/posts/savory/lentil-dhal/index.md
@@ -4,59 +4,52 @@ date: 2023-01-22T11:11:41+01:00
 draft: false
 tags: ["lunch", "gluten-free", "red-lentils", "legumes", "zucchini"]
 categories: ["Savory"]
+prepTime: 10
+cookTime: 20
+servings: "2 servings"
+ingredients:
+  - "2 cups boiling water"
+  - "1 medium onion"
+  - "2 cloves of garlic"
+  - "1 tablespoon of coconut oil or neutral oil"
+  - "150g red lentils, rinsed"
+  - "1/2 can of coconut milk"
+  - "1 large tomato"
+  - "1 small zucchini"
+  - "1 small sweet potato / carrot"
+  - "1/2 teaspoon of turmeric or general curry spice"
+  - "1/2 teaspoon of cumin"
+  - "1/2 teaspoon of paprika"
+  - "1/2 teaspoon of mustard seeds"
+  - "## Optionally add"
+  - "1/2 teaspoon of chili powder"
+  - "1/2 teaspoon of garam masala"
+  - "1/2 teaspoon of ginger"
+  - "juice of 1/2 lemon"
+  - "garnish of fresh cilantro or other herbs"
+steps:
+  - "Heat the oil in a large pot over medium heat."
+  - "Add the cumin (and other whole spices) and onion and cook until the onion is translucent."
+  - "Add the hard vegetables like sweet potato and carrot and get some color on them."
+  - "Add the garlic and dry spices (excluding turmeric which gets destroyed if cooked for too long and makes the dish bitter)."
+  - "Add the lentils and stir until they are coated in the spices."
+  - "Add the tomato and zucchini and gently stir in."
+  - "Add the boiling water. Everything should be covered by a centimeter or so of water."
+  - "Bring to a boil and then reduce the heat to a simmer."
+  - "Cook for 15 minutes or until the lentils are soft. Stir occasionally and add water if needed."
+  - "Add the coconut milk and turmeric and stir until combined."
+  - "Add the lemon juice and season with salt and pepper to taste."
+  - "Serve with rice or bread and garnish with fresh herbs."
 ---
 
-Dhal is a traditional indian dish made of lentils and spices, often served with rice or bread and garnished with fresh herbs. It's super easy to make and just absolutely delicious! 
+Dhal is a traditional Indian dish made of lentils and spices, often served with rice or bread and garnished with fresh herbs. It's super easy to make and just absolutely delicious!
 
-Dhal typically includes a combination of lentils, spices, 
-and aromatics such as onion and garlic. Common spices include turmeric, cumin, 
-and mustard seeds (my favorite). Some variations also include ginger, chilies, and tomatoes. 
-It is generally served with rice or bread, and garnished with fresh 
+Dhal typically includes a combination of lentils, spices,
+and aromatics such as onion and garlic. Common spices include turmeric, cumin,
+and mustard seeds (my favorite). Some variations also include ginger, chilies, and tomatoes.
+It is generally served with rice or bread, and garnished with fresh
 cilantro or other herbs.
 
 Dhal is a very flexible dish and you can add a variety of vegetables to it.
 Don't be afraid to add in local vegetables that you have on hand. In this recipe I have
-used some zucchini, sweet potato and a tomato. 
-
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 20 minutes
-
-### Ingredients for 2 servings
-- [ ] 2 cups boiling water
-- [ ] 1 medium onion
-- [ ] 2 cloves of garlic
-- [ ] 1 tablespoon of coconut oil or neutral oil
-- [ ] 150g red lentils, rinsed
-- [ ] 1/2 can of coconut milk
-- [ ] 1 large tomato
-- [ ] 1 small zucchini
-- [ ] 1 small sweet potato / carrot
-- [ ] 1/2 teaspoon of turmeric or general curry spice
-- [ ] 1/2 teaspoon of cumin
-- [ ] 1/2 teaspoon of paprika
-- [ ] 1/2 teaspoon of mustard seeds
-#### Optionally add
-- [ ] 1/2 teaspoon of chili powder
-- [ ] 1/2 teaspoon of garam masala
-- [ ] 1/2 teaspoon of ginger
-- [ ] juice of 1/2 lemon
-- [ ] garnish of fresh cilantro or other herbs
-
-### Steps
-1. Heat the oil in a large pot over medium heat.
-2. Add the cumin (and other whole spices) and onion and cook until the onion is translucent.
-3. Add the hard vegetables like sweet potato and carrot and get some color on them.
-4. Add the garlic and dry spices (excluding turmeric which gets destroyed if cooked for too long and makes the dish bitter).
-5. Add the lentils and stir until they are coated in the spices.
-6. Add the tomato and zucchini and gently stir in.
-7. Add the boiling water. Everything should be covered by a centimeter or so of water.
-8. Bring to a boil and then reduce the heat to a simmer.
-9. Cook for 15 minutes or until the lentils are soft. Stir occasionally and add water if needed.
-10. Add the coconut milk and turmeric and stir until combined.
-11. Add the lemon juice and season with salt and petter to taste.
-12. Serve with rice or bread and garnish with fresh herbs.
-
-</div>
+used some zucchini, sweet potato and a tomato.

--- a/content/posts/savory/oyster-mushroom-risotto/index.md
+++ b/content/posts/savory/oyster-mushroom-risotto/index.md
@@ -4,45 +4,38 @@ date: 2023-02-17T11:11:41+01:00
 draft: false
 tags: ["lunch", "gluten-free", "risotto", "mushrooms", "spinach", "italian"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 30
+servings: "2 servings"
+ingredients:
+  - "300g arborio rice"
+  - "1 small onion, finely chopped"
+  - "1/2 stalk celery, finely chopped"
+  - "1 medium carrot, cut into small cubes"
+  - "3 cloves of garlic, finely chopped"
+  - "1 cup of oyster mushrooms, chopped"
+  - "1 cup of spinach, roughly chopped"
+  - "1.5l vegetable stock"
+  - "2 tablespoons olive oil"
+  - "splash of white wine (optional)"
+  - "salt and pepper to taste"
+  - "1 tablespoon nutritional yeast"
+  - "1 tablespoon vegan butter"
+  - "sprinkle of thyme"
+  - "juice of 1/2 small lemon"
+steps:
+  - "Heat the oil in a large pot over medium heat."
+  - "Add the onion, celery and carrot and cook until the onion is translucent."
+  - "Add the garlic and cook for another minute."
+  - "Add the rice and mushrooms and stir until coated in the oil."
+  - "Toast the rice with mushrooms for a minute or two, then deglaze with wine or water and stir until it is absorbed."
+  - "Add the stock, a cup or so at a time, stirring until it is fully absorbed before adding more."
+  - "When the rice is almost done, add the spinach and cook until wilted."
+  - "Add the butter, nutritional yeast, thyme and lemon juice and season with salt and pepper to taste."
 ---
 
-Risotto is an exercise in patience and knife skill. Today we have a simple oyster mushroom risotto with spinach that is 
+Risotto is an exercise in patience and knife skill. Today we have a simple oyster mushroom risotto with spinach that is
 creamy, savory and just so good!
 
 Really make sure to use a good quality stock. Today I cheated and used a vegetable stock cube, but the stock makes or breaks the dish.
 Also, the finer you chop the onion and garlic, the better. You want them to essentially melt into the rice. I take my time and chop them very finely.
-
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 30 minutes
-
-### Ingredients for 2 servings
-- [ ] 300g arborio rice
-- [ ] 1 small onion, finely chopped
-- [ ] 1/2 stalk celery, finely chopped
-- [ ] 1 medium carrot, cut into small cubes
-- [ ] 3 cloves of garlic, finely chopped
-- [ ] 1 cup of oyster mushrooms, chopped
-- [ ] 1 cup of spinach, roughly chopped
-- [ ] 1.5l vegetable stock
-- [ ] 2 tablespoons olive oil
-- [ ] splash of white wine (optional)
-- [ ] salt and pepper to taste
-- [ ] 1 tablespoon nutritional yeast
-- [ ] 1 tablespoon vegan butter
-- [ ] sprinkle of thyme
-- [ ] juice of 1/2 small lemon
-
-### Steps
-1. Heat the oil in a large pot over medium heat.
-2. Add the onion, celery and carrot and cook until the onion is translucent.
-3. Add the garlic and cook for another minute.
-4. Add the rice and mushrooms and stir until coated in the oil.
-5. Toast the rice with mushrooms for a minute or two, then deglaze with wine or water and stir until it is absorbed.
-6. Add the stock, a cup or so at a time, stirring until it is fully absorbed before adding more.
-7. When the rice is almost done, add the spinach and cook until wilted.
-8. Add the butter, nutritional yeast, thyme and lemon juice and season with salt and pepper to taste.
-
-</div>

--- a/content/posts/savory/pea-soup/index.md
+++ b/content/posts/savory/pea-soup/index.md
@@ -4,32 +4,26 @@ date: 2023-01-24T14:11:41+01:00
 draft: false
 tags: ["gluten-free", "legumes", "soup", "simple"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 10
+servings: "5 servings"
+ingredients:
+  - "500g frozen peas"
+  - "3 cloves of garlic"
+  - "2 teaspoons olive oil"
+  - "1.5 tablespoons paprika"
+  - "2 teaspoons marjoram"
+  - "salt and pepper to taste"
+  - "## Optionally add"
+  - "chili powder to taste"
+steps:
+  - "Heat the oil in a pan over medium high heat and add your garlic, finely chopped."
+  - "After the garlic has some color, add the paprika powder."
+  - "Do not cook the dry paprika for too long as it will become bitter."
+  - "Quickly add the frozen peas and mix."
+  - "Sauté the peas for about a minute and then pour in boiling water."
+  - "Bring to a boil and cook for about 5 minutes."
+  - "Finish with the marjoram and season with salt and pepper to taste."
 ---
 
 This very simple pea soup is everything you need after a long day in the coldness of this world. It tastes fresh, which is an achievement considering it is made from frozen peas!
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 10 minutes
-
-### Ingredients for 5 servings
-- [ ] 500g frozen peas
-- [ ] 3 cloves of garlic
-- [ ] 2 teaspoons olive oil
-- [ ] 1.5 tablespoons paprika
-- [ ] 2 teaspoons marjoram
-- [ ] salt and pepper to taste
-#### Optionally add
-- [ ] chili powder to taste
-
-### Steps
-1. Heat the oil in a pan over medium high heat and add your garlic, finely chopped.
-2. After the garlic has a some color, add the paprika powder.
-3. Do not cook the dry paprika for too long as it will become bitter.
-4. Quickly add the frozen peas and mix.
-5. Sauteé the peas for about a minute and then pour in boiling water.
-6. Bring to a boil and cook for about 5 minutes.
-7. Finish with the marjoram and season with salt and pepper to taste.
-
-</div>

--- a/content/posts/savory/potato-dumplings/index.md
+++ b/content/posts/savory/potato-dumplings/index.md
@@ -4,6 +4,40 @@ date: 2023-04-24T10:00:00+01:00
 draft: false
 tags: ["legumes", "czech", "lunch"]
 categories: ["Savory"]
+prepTime: 15
+cookTime: 60
+servings: "2 servings"
+ingredients:
+  - "## For the cabbage"
+  - "1 head medium red cabbage, shredded"
+  - "1 tbsp neutral oil"
+  - "1 tsp garlic powder"
+  - "1 red onion, finely chopped"
+  - "1 small apple, finely grated"
+  - "1 tbsp salt"
+  - "1/2 tbsp brown sugar"
+  - "## For the dumplings"
+  - "200g potato dumpling flour"
+  - "200g water"
+  - "## For the filling"
+  - "40g protein powder (I used a mix of pea and rice)"
+  - "1 tsp smoked paprika powder"
+  - "1 tsp garlic powder"
+  - "1 tsp onion powder"
+  - "1 tsp salt"
+  - "1 tsp pepper"
+  - "1 tsp neutral oil"
+  - "## Optionally add"
+  - "chili powder to taste"
+steps:
+  - "Heat the oil in a pan over medium high heat and add your onion. Cook until translucent."
+  - "Add the cabbage and cook until it starts to wilt."
+  - "Add the garlic powder, salt and sugar. Pour in water so that the cabbage is submerged. Cook until the cabbage is soft. Then add the apple and cook for another 5 minutes."
+  - "In a bowl, mix the protein powder with the spices and oil. Add water until you get a thick paste."
+  - "In another bowl, mix the dumpling flour with the water until you get a dough."
+  - "Take a small piece of dough and flatten it. Add a small amount of filling and close the dough around it. Repeat until you run out of dough."
+  - "Bring a pot of water to a boil and add the dumplings. Cook for 10 minutes. When the dumplings float, they are done."
+  - "Serve the dumplings with the cabbage, garnish with caramelized onions."
 ---
 
 This is a take on a Czech (I assume) recipe for potato dumplings with red cabbage. This took some thought because the filling is usually done with tofu and that's not something I find appealing in a dumpling.
@@ -11,43 +45,3 @@ This is a take on a Czech (I assume) recipe for potato dumplings with red cabbag
 Therefore, these use some protein powder with spices as filling. It is inspired by a restaurant I frequent, and it makes for a much better filling in my opinion.
 
 In this recipe I cheated and used premade potato dumpling flour. You can make them yourself, they are actually quite simple to make. I thought it would take too much time.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 60 minutes
-
-### Ingredients for 2 servings
-#### For the cabbage
-- [ ] 1 head medium red cabbage, shredded
-- [ ] 1 tbsp neutral oil
-- [ ] 1 tsp garlic powder
-- [ ] 1 red onion, finely chopped
-- [ ] 1 small apple, finely grated
-- [ ] 1 tbsp salt
-- [ ] 1/2 tbsp brown sugar
-#### For the dumplings
-- [ ] 200g potato dumpling flour
-- [ ] 200g water
-#### For the filling
-- [ ] 40g protein powder (I used a mix of pea and rice)
-- [ ] 1 tsp smoked paprika powder
-- [ ] 1 tsp garlic powder
-- [ ] 1 tsp onion powder
-- [ ] 1 tsp salt
-- [ ] 1 tsp pepper
-- [ ] 1 tsp neutral oil
-#### Optionally add
-- [ ] chili powder to taste
-
-### Steps
-1. Heat the oil in a pan over medium high heat and add your onion. Cook until translucent.
-2. Add the cabbage and cook until it starts to wilt.
-3. Add the garlic powder, salt and sugar. Pour in water so that the cabbage is submerged. Cook until the cabbage is soft. Then add the apple and cook for another 5 minutes.
-4. In a bowl, mix the protein powder with the spices and oil. Add water until you get a thick paste.
-5. In another bowl, mix the dumpling flour with the water until you get a dough.
-6. Take a small piece of dough and flatten it. Add a small amount of filling and close the dough around it. Repeat until you run out of dough.
-7. Bring a pot of water to a boil and add the dumplings. Cook for 10 minutes. When the dumplings float, they are done.
-8. Serve the dumplings with the cabbage, garnish with caramelized onions.
-
-</div>

--- a/content/posts/savory/puff-pastry-snails/index.md
+++ b/content/posts/savory/puff-pastry-snails/index.md
@@ -4,29 +4,23 @@ date: 2024-01-01T12:00:00+01:00
 draft: false
 tags: ["puff-pastry", "simple", "snack", "party-food"]
 categories: ["Savory"]
+prepTime: 10
+cookTime: 20
+servings: "many snails"
+ingredients:
+  - "1 puff pastry sheet"
+  - "1/2 can of chopped tomatoes"
+  - "1/2 block vegan cheese, grated coarsely"
+  - "2 tbsp mixed herbs (I used basil and oregano)"
+  - "2 tsp salt"
+  - "1 tbsp sesame seeds"
+steps:
+  - "Preheat the oven to 200°C."
+  - "Mix the tomatoes, herbs and salt in a bowl."
+  - "Roll out the puff pastry sheet and spread the tomato mixture on top."
+  - "Sprinkle the cheese on top and roll up the pastry sheet starting from the long side."
+  - "Cut the roll into ~1cm thick slices and place them on a baking tray lined with parchment paper."
+  - "Sprinkle the sesame seeds on top and bake for 20 minutes or until golden brown."
 ---
 
 Kicking off the new year with a very fitting recipe for puff pastry snails. These are a great snack to serve at a party. They tasted like lasagna, so take that as you will :).
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 20 minutes
-
-### Ingredients for... so many snails
-- [ ] 1 puff pastry sheet
-- [ ] 1/2 can of chopped tomatoes
-- [ ] 1/2 block vegan cheese, grated coarsely
-- [ ] 2 tbsp mixed herbs (I used basil and oregano)
-- [ ] 2 tsp salt
-- [ ] 1 tbsp sesame seeds
-
-### Steps
-1. Preheat the oven to 200°C.
-2. Mix the tomatoes, herbs and salt in a bowl.
-3. Roll out the puff pastry sheet and spread the tomato mixture on top.
-4. Sprinkle the cheese on top and roll up the pastry sheet starting from the long side.
-5. Cut the roll into ~1cm thick slices and place them on a baking tray lined with parchment paper.
-6. Sprinkle the sesame seeds on top and bake for 20 minutes or until golden brown.
-
-</div>

--- a/content/posts/savory/quinoa salad/index.md
+++ b/content/posts/savory/quinoa salad/index.md
@@ -4,40 +4,31 @@ date: 2025-06-17T12:00:00+01:00
 draft: false
 tags: ["quinoa", "salad"]
 categories: ["Savory"]
+prepTime: 10
+cookTime: 15
+servings: "3 servings"
+ingredients:
+  - "200g dry quinoa"
+  - "1/2 cucumber, diced"
+  - "1 bell pepper, diced"
+  - "100g cherry tomatoes, halved"
+  - "1 pomegranate worth of seeds"
+  - "1 can chickpeas (drained)"
+  - "mixed salad leaves (about 200g)"
+  - "## For the dressing"
+  - "3 tbsp olive oil"
+  - "juice of 1 lime"
+  - "1 tsp salt"
+  - "1/2 tsp black pepper"
+  - "## Optionally add"
+  - "herbs (parsley, mint, or cilantro work well)"
+  - "olives"
+steps:
+  - "Rinse the quinoa under cold water. Cook covered in a pot with 600ml water for about 15 minutes, or until the quinoa is fluffy and the water is absorbed. Rinse under cold water to stop the cooking process."
+  - "In a large bowl, combine the cooked quinoa, cucumber, bell pepper, cherry tomatoes, pomegranate seeds, and chickpeas."
+  - "In a small mason jar or covered glass, mix the olive oil, lime juice, salt, and pepper. Shake well to emulsify."
+  - "Pour the dressing over the quinoa salad and toss gently to combine."
+  - "Serve cold — keeps well for a few days."
 ---
 
 Just so you know, quinoa triples in size when cooked. I could feed an army. Quinoa is healthy stuff and a salad like this is my favorite way to eat it :)
-
-<div class="recipe" id="recipe">
-
-Cooking time: 15 minutes
-
-Prep time: 10 minutes
-
-### Ingredients for 3 servings
-- [ ] 200g dry quinoa
-- [ ] 1/2 cucumber, diced
-- [ ] 1 bell pepper, diced
-- [ ] 100g cherry tomatoes, halved
-- [ ] 1 pomegranate worth of seeds
-- [ ] 1 can chickpeas (without the water duh)
-- [ ] mixed salad leaves (about 200g)
-For the dressing:
-- [ ] 3 tbsp olive oil
-- [ ] juice of 1 lime
-- [ ] 1 tsp salt
-- [ ] 1/2 tsp black pepper
-
-#### Optionally add
-- [ ] herbs (parsley, mint, or cilantro work well)
-- [ ] olives
-- [ ] anything else really, I'm not your mother
-
-### Steps
-1. Rinse the quinoa under cold water. Cook covered in a pot with 600ml water for about 15 minutes, or until the quinoa is fluffy and the water is absorbed. Let it cool or rinse under cold water to stop the cooking process. (that's what I did becuase why not)
-2. In a large bowl, combine the cooked quinoa, cucumber, bell pepper, cherry tomatoes, pomegranate seeds, and chickpeas.
-3. In a small mason jar or a covered glass, mix the olive oil, lime juice, salt, and pepper. Shake well to emulsify.
-4. Pour the dressing over the quinoa salad and toss gently to combine.
-5. Serve and enjoy! Best eaten cold, keeps for a few days.
-
-</div>

--- a/content/posts/savory/red-lentil-curry/index.md
+++ b/content/posts/savory/red-lentil-curry/index.md
@@ -4,40 +4,35 @@ date: 2023-09-22T12:00:00+01:00
 draft: false
 tags: ["lunch", "gluten-free", "red-lentils", "legumes", "spicy", "sweet-potato"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 45
+servings: "4 servings"
+ingredients:
+  - "1.5 cups uncooked red lentils, rinsed"
+  - "1 large sweet potato, or 2 medium carrots"
+  - "1/2 small zucchini, sliced into longer pieces about 1 cm thick"
+  - "1 large red onion, chopped"
+  - "4 cloves of garlic, grated or finely chopped"
+  - "small piece of ginger, grated or finely chopped"
+  - "1 can tomatoes"
+  - "1/2 can coconut milk"
+  - "1 tablespoon coconut oil"
+  - "1 tablespoon curry spice"
+  - "salt and pepper and other herbs to taste"
+  - "## Optionally add"
+  - "a desired amount of leafy green vegetables (stay healthy!)"
+  - "juice of 1/2 lemon"
+steps:
+  - "Rinse your red lentils and set aside."
+  - "Start by cutting up your vegetables into bite size pieces. Try using longer shapes as opposed to cubes."
+  - "Heat the coconut oil in a pan and sauté the onion. After it turns translucent, add your garlic and ginger."
+  - "Add the lentils to the pan along with the tomatoes, sweet potato and zucchini."
+  - "Cover with enough water to have about 2cm of liquid above the surface and cover with a lid."
+  - "Bring down the heat and simmer over medium until the red lentils are quite soft."
+  - "Stir in your dry spices, optional ingredients and add the coconut milk."
+  - "Serve over rice."
 ---
 
 I find myself in a bit of a curry rush lately, especially with the weather turning so chilly. As a natural reaction, of course, I have started cooking dense and filling dishes again. I also happen to like the way they look, albeit quite bare.
 
 Here today is a *very* simple curry recipe even the most frostbitten of us can cook up in a heartbeat.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 45 minutes
-
-### Ingredients for 4 servings
-- [ ] 1.5 cups uncooked red lentils, rinsed
-- [ ] 1 large sweet potato, or 2 medium carrots
-- [ ] 1/2 small zuccini, sliced into longer pieces about 1 cm thick
-- [ ] 1 large red onion, chopped
-- [ ] 4 cloves of garlic, grated or finely chopped
-- [ ] small piece of ginger, grated or finely chopped
-- [ ] 1 can tomatoes
-- [ ] 1/2 coconut milk
-- [ ] 1 tablespoon coconut oil
-- [ ] 1 tablespoon curry spice
-- [ ] salt and pepper and other herbs to taste
-#### Optionally add
-- [ ] a desired amount of leafy green vegetables (stay healthy!)
-- [ ] juice of 1/2 lemon
-
-### Steps
-Rinse your red lentils and set aside.
-1. Start by cutting up your vegetables into bite size pieces. Try using longer shapes as opposed to cubes.
-2. Heat the coconut oil in a pan and sauté the onion. After it turns translucent, add your garlic and ginger.
-3. Add the lentils to the pan along with the tomatoes, sweet potato and zuccini.
-4. Cover with enough water to have about 2cm of liquid above the surface and cover with a lid.
-5. Bring down the heat and simmer over medium until the red lentils are quite soft.
-6. Stir in your dry spices, optional ingredients and add the coconut milk.
-7. Serve over rice.
-</div>

--- a/content/posts/savory/rice-paper-dumplings/index.md
+++ b/content/posts/savory/rice-paper-dumplings/index.md
@@ -4,13 +4,36 @@ date: 2024-01-14T12:00:00+01:00
 draft: false
 tags: ["rice-paper", "dumplings", "asian"]
 categories: ["Savory"]
+prepTime: 20
+cookTime: 15
+servings: "8 dumplings"
+ingredients:
+  - "1/4 cabbage (~250g)"
+  - "1 medium carrot"
+  - "1 block of tofu (200g)"
+  - "3 cloves of garlic, minced"
+  - "about the same amount in ginger, minced"
+  - "1 tbsp soy sauce"
+  - "1 tbsp sesame oil"
+  - "salt and pepper to taste"
+steps:
+  - "Chop the cabbage as finely as you can. Grate the carrot."
+  - "Add the cabbage and carrot to a mixing bowl."
+  - "Crumble in your tofu and add the garlic, ginger, soy sauce, sesame oil, salt and pepper."
+  - "Mix until combined."
+  - "Take a rice paper sheet and dip it in water until it's soft."
+  - "Add about 3 tbsp of filling to the center of the rice paper."
+  - "Fold the rice paper over the filling and roll it up."
+  - "Repeat until you run out of filling. The measurements above should make about 8 very well filled dumplings."
+  - "Heat up a pan with a bit of oil and fry the dumplings on both sides until golden brown."
+  - "Ideally serve with a dipping sauce, I tend not to bother :)"
 ---
 
 This recipe is brought to you by: The long shelf life of rice paper; Made by finally using up my old pack of partially shattered rice paper. Tasty rice paper dumplings, filled with a simple tofu & cabbage filling.
 
 Now, I have picked up on the frowns of any Asian foodie, rice paper dumplings are somewhat of a sacrilege. But they taste nice and I think that's all that counts :)
 
-Here is the shot of the filling, make sure to not overfill the dumplings, or they will break. Also, you want to chop the cabbage as finely as you can. These cook very quickly and you don't want raw cabbage!
+Here is the shot of the filling — make sure to not overfill the dumplings, or they will break. Also, you want to chop the cabbage as finely as you can. These cook very quickly and you don't want raw cabbage!
 
 ![Filling](filling.png)
 
@@ -21,32 +44,3 @@ Here's a quick video on how to wrap these. You don't have to double wrap, but th
     <source src="/videos/52CC3982-2200-4E6B-8349-FDE022245C15.webm" type="video/webm">
     Your browser does not support the video tag.
 </video>
-
-<div class="recipe" id="recipe">
-Prep time: 20 minutes
-
-Cooking time: 15 minutes
-
-### Ingredients for 8 dumplings
-- [ ] 1/4 cabbage (~250g)
-- [ ] 1 medium carrot
-- [ ] 1 block of tofu (200g)
-- [ ] 3 cloves of garlic, minced
-- [ ] about the same in ginger, minced
-- [ ] 1 tbsp soy sauce
-- [ ] 1 tbsp sesame oil
-- [ ] salt and pepper to taste
-
-### Steps
-1. Chop the cabbage as finely as you can. Grate the carrot.
-2. Add the cabbage and carrot to a mixing bowl.
-3. Crumble in your tofu and add the garlic, ginger, soy sauce, sesame oil, salt and pepper.
-4. Mix until combined.
-5. Take a rice paper sheet and dip it in water until it's soft.
-6. Add about 3 tbsp of filling to the center of the rice paper.
-7. Fold the rice paper over the filling and roll it up.
-8. Repeat until you run out of filling. The measurements above should make about 8 very well filled dumplings.
-9. Heat up a pan with a bit of oil and fry the dumplings on both sides until golden brown.
-10. Ideally serve with a dipping sauce, I tend not to bother :)
-
-</div>

--- a/content/posts/savory/ricenoodle-tofu/index.md
+++ b/content/posts/savory/ricenoodle-tofu/index.md
@@ -4,40 +4,34 @@ date: 2023-03-27T11:00:41+01:00
 draft: false
 tags: ["lunch", "gluten-free", "tofu", "rice-noodles"]
 categories: ["Savory"]
+prepTime: 15
+cookTime: 30
+servings: "2 servings"
+ingredients:
+  - "1 block firm tofu"
+  - "2 tablespoons soy sauce"
+  - "1 small onion, finely chopped"
+  - "2 cloves garlic, minced"
+  - "1/2 tablespoon ginger, dried"
+  - "100g rice noodles"
+  - "2 tablespoons coconut oil"
+  - "1 small carrot, thin shavings using a peeler"
+  - "1/2 red pepper, long strips"
+  - "1/2 small broccoli"
+  - "2 tablespoons potato starch"
+steps:
+  - "Cook the rice noodles according to the instructions on the package."
+  - "Cut the tofu into 1cm cubes and mix in the potato starch."
+  - "Heat the coconut oil in a pan over medium heat."
+  - "Add the tofu and fry until golden brown."
+  - "Mix soy sauce, 3/4 tablespoon starch and ginger in some water."
+  - "Pour in the sauce and cook until the sauce has thickened and covered the tofu."
+  - "Remove from the pan and add extra oil."
+  - "Add the onion, garlic, carrot and broccoli and cook until the onion is translucent."
+  - "Add the red pepper and cook for another minute."
+  - "Add the rice noodles and mix until everything is coated in the sauce."
+  - "Serve with the tofu on top. Optionally garnish with green onions, or sesame seeds."
 ---
 
 For a cooking site calling itself after tofu, I sure rarely add any tofu recipes!
 Today we are changing that with a pretty simple recipe for fried tofu with rice noodles.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 1 hour
-
-### Ingredients for 2 servings
-- [ ] 1 block firm tofu
-- [ ] 2 tablespoons soy sauce
-- [ ] 1 small onion, finely chopped
-- [ ] 2 cloves garlic, minced
-- [ ] 1/2 tablespoon ginger, dried
-- [ ] 100g rice noodles
-- [ ] 2 tablespoons coconut oil
-- [ ] 1 small carrot, thin shavings using a peeler
-- [ ] 1/2 red pepper, long strips
-- [ ] 1/2 small broccoli
-- [ ] 2 tablespoons potato starch
-
-### Steps
-Cook the rice noodles according to the instructions on the package.
-1. Cut the tofu into 1cm cubes and mix in the potato starch.
-2. Heat the coconut oil in a pan over medium heat.
-3. Add the tofu and fry until golden brown.
-4. Mix soy sauce, 3/4 tablespoon starch and ginger in some water.
-5. Pour in the sauce and cook until the sauce has thickened and covered the tofu.
-6. Remove from the pan and add extra oil.
-7. Add the onion, garlic and carrot and broccoli and cook until the onion is translucent.
-8. Add the red pepper and cook for another minute.
-9. Add the rice noodles and mix until everything is coated in the sauce.
-10. Serve with the tofu on top. Optionally garnish with green onions, or sesame seeds.
-
-</div>

--- a/content/posts/savory/split-pea-soup/index.md
+++ b/content/posts/savory/split-pea-soup/index.md
@@ -4,35 +4,29 @@ date: 2024-04-15T12:00:00+01:00
 draft: false
 tags: ["gluten-free", "legumes", "soup", "simple"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 45
+servings: "2 servings"
+ingredients:
+  - "500g dry split peas"
+  - "1 medium onion, chopped"
+  - "3 medium carrots"
+  - "2 cloves of garlic"
+  - "1 tbsp olive oil"
+  - "1 tbsp marjoram"
+  - "salt and pepper to taste"
+steps:
+  - "Rinse the split peas and soak them in water for at least 1 hour."
+  - "In a large pot, heat the olive oil and sauté the onion and garlic until fragrant."
+  - "Add the split peas and 1.5L of water to the pot. (should cover the peas by at least 2cm)"
+  - "Bring to a boil and then reduce the heat to a simmer."
+  - "Add the carrots in medium chunks."
+  - "Cook for 30 minutes on medium or until the peas are soft."
+  - "Add the marjoram, salt and pepper."
+  - "Mash slightly with a potato masher or give a quick blend with a hand blender."
+  - "Serve hot."
 ---
 
 A simple and hearthy soup full of protein and fiber. One pot preparation guaranteed. Good with bread, or some croutons if you're feeling fancy.
 
 *Tip: While cooking, the peas will initially produce some nasty foam. Skim this off periodically.*
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 45 minutes
-
-### Ingredients for 2 servings
-- [ ] 500g dry split peas
-- [ ] 1 medium onion, chopped
-- [ ] 3 medium carrots
-- [ ] 2 cloves of garlic
-- [ ] 1 tbsp olive oil
-- [ ] 1 tbsp majoram
-- [ ] salt and pepper to taste
-
-### Steps
-1. Rinse the split peas and soak them in water for at least 1 hour.
-2. In a large pot, heat the olive oil and sauté the onion and garlic until fragrant.
-3. Add the split peas and 1.5L of water to the pot. (should cover the peas by at least 2cm)
-4. Bring to a boil and then reduce the heat to a simmer.
-5. Add the carrots in medium chunks.
-6. Cook for 30 minutes on medium or until the peas are soft.
-7. Add the majoram, salt and pepper.
-8. Mash slightly with a potato masher or give a quick blend with a hand blender.
-9. Serve hot.
-
-</div>

--- a/content/posts/savory/strips-veggie-rice-bown/index.md
+++ b/content/posts/savory/strips-veggie-rice-bown/index.md
@@ -4,38 +4,32 @@ date: 2023-03-16T14:11:41+01:00
 draft: false
 tags: ["gluten-free", "rice-bowl", "rice", "zucchini"]
 categories: ["Savory"]
+prepTime: 3
+cookTime: 10
+servings: "1 serving"
+ingredients:
+  - "200g white rice"
+  - "1 tablespoon coconut oil"
+  - "100g package of vegan strips"
+  - "1/4 small zucchini, in thin slices"
+  - "1 small onion, finely chopped"
+  - "1 clove of garlic, minced"
+  - "dash of soy sauce"
+  - "1/2 red bell pepper"
+  - "stalk of 1 green onion"
+  - "salt and pepper to taste"
+  - "## Optionally add"
+  - "1 tablespoon nori flakes"
+  - "2 cherry tomatoes"
+steps:
+  - "If the strips come without any seasoning, marinate them for 1 hour in a mixture of soy sauce, curry powder, nutmeg, chilli powder and water."
+  - "Cook the rice according to your preferences."
+  - "Heat the oil in the pan and sauté the onions until translucent together with the garlic."
+  - "When translucent add the zucchini and bell pepper."
+  - "After all have cooked through, add in the marinated strips and mix around."
+  - "Add a dash of soy sauce and salt and pepper."
+  - "Cook for 2 minutes, occasionally adding water if needed."
+  - "Serve over rice with a garnish of green onion."
 ---
 
 This simple dish makes use of some premade vegan soy/seitan strips. They are quite inexpensive and when mixed with a few different veggies, they can taste quite good!
-
-<div class="recipe" id="recipe">
-Prep time: 3 minutes
-
-Cooking time: 10 minutes
-
-### Ingredients for 1 serving
-- [ ] 200g white rice
-- [ ] 1 tablespoon coconut oil
-- [ ] 100g package of vegan strips
-- [ ] 1/4 small zucchini, in thin slices
-- [ ] 1 small onion, finely chopped
-- [ ] 1 clove of garlic, minced
-- [ ] dash of soy sauce
-- [ ] 1/2 red bell pepper
-- [ ] stalk of 1 green onion
-- [ ] salt and pepper to taste
-#### Optionally add
-- [ ] 1 tablespoon nori flakes
-- [ ] 2 cherry tomatoes
-
-### Steps
-If the strips come without any seasoning, marinate the strips for 1 hour in a mixture of soy sauce, curry powder, nutmeg and chilli powder and water.
-1. Cook the rice according to your preferences.
-2. Heat the oil in the pan and sauté the onions until translucent together with the garlic.
-3. When translucent add the zuccini and bell pepper.
-4. After all have cooked through, add in the marinated strips and mix around.
-4. Add a dash of soy sauce and salt and pepper.
-5. Cook for 2 minutes, occasionally adding water if needed.
-6. Serve over rice with a garnish of green onion.
-
-</div>

--- a/content/posts/savory/szegedin/index.md
+++ b/content/posts/savory/szegedin/index.md
@@ -4,37 +4,31 @@ date: 2024-04-26T12:00:00+01:00
 draft: false
 tags: ["lunch", "simple"]
 categories: ["Savory"]
+prepTime: 15
+cookTime: 60
+servings: "5 servings"
+ingredients:
+  - "500g sauerkraut"
+  - "3 onions"
+  - "2 cloves of garlic"
+  - "2 bay leaves"
+  - "1 tbsp dried marjoram"
+  - "300g vegan strips"
+  - "2 tbsp tomato paste"
+  - "2 tbsp flour"
+  - "2 tbsp paprika"
+  - "2 tbsp neutral oil"
+  - "3g caraway seeds"
+  - "1 liter vegetable stock, or water and bouillon"
+  - "splash of white wine"
+steps:
+  - "Chop the onions and garlic. Heat the oil in a large pot and sauté the onions until translucent."
+  - "Add the garlic, caraway seeds, and paprika. Stir for a minute. Then deglaze with a splash of white wine."
+  - "Add the tomato paste and flour. Stir for another minute."
+  - "Add the sauerkraut, strips, marjoram, bay leaves, and vegetable stock. Bring to a boil, then reduce to a simmer."
+  - "Simmer for 1 hour, making sure to stir occasionally. Add more stock if it gets too dry."
+  - "Salt and pepper to taste."
+  - "Serve with dumplings or bread."
 ---
 
 I will gladly be the first to admit that a lot of my recipes lately have been looking a little beige. But no matter! This is a classic Hungarian comfort food. I bought the dumplings pre-made, but you can make them yourself. They're quite simple. I might have a recipe for them soon.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 1 hour
-
-### Ingredients for 5 servings
-- [ ] 500g sauerkraut
-- [ ] 3 onions
-- [ ] 2 cloves of garlic
-- [ ] 2 bay leaves
-- [ ] 1 tbsp dried marjoram
-- [ ] 300g vegan strips
-- [ ] 2 tbsp tomato paste
-- [ ] 2 tbsp flour
-- [ ] 2 tbsp paprika
-- [ ] 2 tbsp neutral oil
-- [ ] 3g caraway seeds
-- [ ] 1 liter vegetable stock, or water and bouillon
-- [ ] splash of white wine
-
-### Steps
-1. Chop the onions and garlic. Heat the oil in a large pot and sauté the onions until translucent.
-2. Add the garlic, caraway seeds, and paprika. Stir for a minute. Then deglaze with a splash of white wine.
-3. Add the tomato paste and flour. Stir for another minute.
-4. Add the sauerkraut, strips, marjoram, bay leaves, and vegetable stock. Bring to a boil, then reduce to a simmer.
-5. Simmer for 1 hour, making sure to stir occasionally. Add more stock if it gets too dry.
-6. Salt and pepper to taste.
-7. Serve with dumplings or bread.
-
-</div>

--- a/content/posts/savory/tempeh-ramen/index.md
+++ b/content/posts/savory/tempeh-ramen/index.md
@@ -4,37 +4,31 @@ date: 2024-02-28T11:00:00+01:00
 draft: false
 tags: ["lunch", "asian", "ramen", "chili", "tempeh"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 25
+servings: "2 servings"
+ingredients:
+  - "1/2 onion, finely chopped"
+  - "1 medium carrot, in long thin strips"
+  - "50/50 split of coconut cream and cashew cream"
+  - "1/2 block of tempeh, cut into bite-sized pieces"
+  - "1 serving of ramen noodles"
+  - "3/4 liter vegetable stock"
+  - "sprouted mung beans for garnish"
+  - "1/2 teaspoon of chili flakes / chili powder"
+  - "1/2 teaspoon of ginger powder"
+  - "2 cloves of garlic, minced"
+  - "1/2 tbsp coconut oil"
+steps:
+  - "In a large pot, heat the coconut oil and sauté the onion and garlic until soft."
+  - "Add the carrot and quickly sauté for 1 minute."
+  - "Add the vegetable stock, the chili and ginger powder and let it simmer for 15 minutes."
+  - "Prepare the ramen noodles according to the package instructions."
+  - "In a separate pan, fry the tempeh until golden brown. Alternatively use an air fryer."
+  - "Add the coconut and cashew cream to the broth and stir well."
+  - "Serve the ramen in a bowl, pour the broth over it and add the tempeh and mung beans on top."
 ---
 
-As my first attempt at anything resembling ramen, this recipe for a chili ramen with tempeh turned out great! Ramen is a sort of a mysterious ingredient to me. It's from a different culture and cuisine and isn't server in my country. What better reason to try it out!? Maybe one day I will get to try the real deal, but for now, this will do :) .
+As my first attempt at anything resembling ramen, this recipe for a chili ramen with tempeh turned out great! Ramen is a sort of a mysterious ingredient to me. It's from a different culture and cuisine and isn't served in my country. What better reason to try it out!? Maybe one day I will get to try the real deal, but for now, this will do :) .
 
 Features a broth, some coconut/cashew cream, and a bunch of veggies.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 25 minutes
-
-### Ingredients for 2 servings
-- [ ] 1/2 onion, finely chopped
-- [ ] 1 medium carrot, in long thin strips
-- [ ] 50/50 split of coconut cream and cashew cream
-- [ ] 1/2 block of tempeh, cut into bite-sized pieces
-- [ ] 1 serving of ramen noodles
-- [ ] 3/4 liter vegetable stock
-- [ ] sprouted mung beans for garnish
-- [ ] 1/2 teaspoon of chili flakes / chili powder
-- [ ] 1/2 teaspoon of ginger powder
-- [ ] 2 cloves of garlic, minced
-- [ ] 1/2 tbsp coconut oil
-
-### Steps
-1. In a large pot, heat the coconut oil and saute the onion and garlic until soft.
-2. Add the carrot and quickly saute for 1 minute.
-3. Add the vegetable stock, the chili and ginger powder and let it simmer for 15 minutes.
-4. Prepare the ramen noodles according to the package instructions.
-5. In a separate pan, fry the tempeh until golden brown. Alternatively use an air fryer.
-6. Add the coconut and cashew cream to the broth and stir well.
-7. Serve the ramen in a bowl, pour the broth over it and add the tempeh and mung beans on top.
-
-</div>

--- a/content/posts/savory/tofu-scramble/index.md
+++ b/content/posts/savory/tofu-scramble/index.md
@@ -4,35 +4,29 @@ date: 2023-01-18T14:00:00+01:00
 draft: false
 tags: ["lunch", "gluten-free", "tofu", "simple"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 5
+servings: "1 serving"
+ingredients:
+  - "1 block of tofu"
+  - "1/2 onion (red is better)"
+  - "1 clove of garlic"
+  - "4 cherry tomatoes"
+  - "some spring onions"
+  - "1 teaspoon of curry spice"
+  - "1 teaspoon of coconut oil or neutral oil"
+  - "salt and pepper to taste"
+steps:
+  - "Mash up the tofu first. I usually squish it with my hands through the packaging. If yours comes in thick plastic you can mash it with a fork instead."
+  - "Heat the oil in a large pan over medium heat."
+  - "Add the onion and cook until the onion is translucent."
+  - "Add in the tomatoes and tofu and stir around."
+  - "Cook for a bit and then add your curry spice (we add it at the end because turmeric should not be cooked for long)."
+  - "Pour in some water, or plant based milk and stir until combined and cooked through."
 ---
 
 Tofu scramble is one of the simplest dishes to make using tofu.
-Tofu is cheap has a lot of protein and is usually enriched with calcium.
+Tofu is cheap, has a lot of protein and is usually enriched with calcium.
 
 I usually make mine with curry spice, but as any simple dish like this you can
 use whatever you have on hand.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 5 minutes
-
-### Ingredients for 1 serving
-- [ ] 1 block of tofu
-- [ ] 1/2 onion (red is better)
-- [ ] 1 clove of garlic
-- [ ] 4 cherry tomatoes
-- [ ] some spring onions
-- [ ] 1 teaspoon of curry spice
-- [ ] 1 teaspoon of coconut oil or neutral oil
-- [ ] salt and pepper to taste
-
-### Steps
-You will need to mash up the tofu first. I usually squish it with my hands through 
-the packaging. If yours comes in thick plastic you can mash it with a fork instead.
-1. Heat the oil in a large pan over medium heat.
-2. Add the onion and cook until the onion is translucent.
-3. Add in the tomatoes and tofu and stir around.
-4. Cook for a bit and then add your curry spice (we add it at the end because turmeric should not be cooked for long).
-5. Pour in some water, or plant based milk and stir until combined and cooked through.
-</div>

--- a/content/posts/savory/winter-soup/index.md
+++ b/content/posts/savory/winter-soup/index.md
@@ -4,38 +4,32 @@ date: 2024-01-16T12:00:00+01:00
 draft: false
 tags: ["soup", "broccoli", "gluten-free", "simple", "sweet-potato", "mushrooms"]
 categories: ["Savory"]
+prepTime: 5
+cookTime: 40
+servings: "5 servings"
+ingredients:
+  - "1 onion, chopped"
+  - "1 cup broccoli, chopped"
+  - "3 cloves of garlic, chopped"
+  - "1 large sweet potato, peeled and cubed"
+  - "50g portobello mushrooms, chopped"
+  - "1 can tomatoes"
+  - "1 can kidney beans"
+  - "1/2 cup green peas"
+  - "1/2 red bell pepper, chopped"
+  - "1 tbsp smoked paprika"
+  - "2 tsp nutritional yeast"
+  - "salt and pepper to taste"
+  - "## Optionally add"
+  - "chili powder to taste"
+  - "1/2 cup corn"
+steps:
+  - "In a large pot, sauté the onion and garlic in a little bit of oil until the onion is translucent."
+  - "Add the sweet potato and mushrooms and sauté for a few minutes."
+  - "Add the tomatoes, bell pepper, broccoli, salt and pepper and optionally chili powder and corn."
+  - "Add water until the vegetables are covered and bring to a boil. Cook until the sweet potato is soft."
+  - "Add the kidney beans, peas, smoked paprika and nutritional yeast and cook for a few more minutes."
+  - "Serve with some bread."
 ---
 
 Not to sound overly modest, but this is one my best soups and it's my personal favorite for a reason. It came about by mixing a few ingredients that are available in winter and it turned out to be a very satisfying soup. I make this on the regular with little to no variation.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 40 minutes
-
-### Ingredients for 5 servings
-- [ ] 1 onion, chopped
-- [ ] 1 cup broccoli, chopped
-- [ ] 3 cloves of garlic, chopped
-- [ ] 1 large sweet potato, peeled and cubed
-- [ ] 50g portobello mushrooms, chopped
-- [ ] 1 can tomatoes
-- [ ] 1 can kidney beans
-- [ ] 1/2 cup green peas
-- [ ] 1/2 red bell pepper, chopped
-- [ ] 1 tbsp smoked paprika
-- [ ] 2 tsp nutritional yeast
-- [ ] salt and pepper to taste
-#### Optionally add
-- [ ] chili powder to taste
-- [ ] 1/2 cup corn
-
-### Steps
-1. In a large pot, sauté the onion and garlic in a little bit of oil until the onion is translucent.
-2. Add the sweet potato and mushrooms and sauté for a few minutes.
-3. Add the tomatoes, bell pepper, broccoli, salt and pepper and optionally chili powder and corn.
-4. Add water until the vegetables are covered and bring to a boil. Cook until the sweet potato is soft.
-5. Add the kidney beans, peas, smoked paprika and nutritional yeast and cook for a few more minutes.
-6. Serve with some bread.
-
-</div>

--- a/content/posts/sweet/apple muffins/index.md
+++ b/content/posts/sweet/apple muffins/index.md
@@ -4,38 +4,32 @@ date: 2023-01-20T23:11:13Z
 draft: false
 tags: ["baked", "muffins"]
 categories: ["Sweet"]
+prepTime: 15
+cookTime: 20
+servings: "1 tray"
+ingredients:
+  - "250g all purpose flour"
+  - "100g brown sugar"
+  - "4g baking soda"
+  - "pinch of salt"
+  - "light grating of nutmeg"
+  - "1 teaspoon of cinnamon"
+  - "180 ml plant based milk"
+  - "60ml vegetable oil (canola, sunflower, or melted vegan butter)"
+  - "5g vanilla extract"
+  - "30g apple sauce or finely grated apple"
+steps:
+  - "Sift the flour, baking soda, salt, nutmeg, and cinnamon into a bowl."
+  - "Add the sugar and mix well."
+  - "Add the milk, oil, and vanilla extract to the bowl."
+  - "Add the apple sauce to the batter and mix well."
+  - "Divide the batter into as many muffin cases as the batter will fill."
+  - "Bake at 180°C for about 20 minutes, or until a skewer comes out clean."
 ---
 
-Are you craving something sweet and filling? Look no further! 
-These homemade apple muffins are the ultimate autumn snack. 
-Not only are they easy to make, but they will also fill your home with the delicious 
-aroma of fresh baked goods. 
+Are you craving something sweet and filling? Look no further!
+These homemade apple muffins are the ultimate autumn snack.
+Not only are they easy to make, but they will also fill your home with the delicious
+aroma of fresh baked goods.
 
 And for an added touch, you can garnish each muffin with your favorite berry on top.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 20 minutes
-
-### Ingredients for 1 tray
-- [ ] 250g All Purpose Flour
-- [ ] 100g Brown Sugar
-- [ ] 4g teaspoon Baking Soda
-- [ ] Pinch of Salt
-- [ ] Light grating of Nutmeg
-- [ ] 1 teaspoon of Cinnamon
-- [ ] 180 ml plant based milk
-- [ ] 60ml vegetable oil (canola, sunflower, melted vegan butter)
-- [ ] 5g Vanilla Extract
-- [ ] 30g Apple Sauce / Finely grated apple
-
-### Steps
-1. Sift the flour, baking soda, salt, nutmeg, and cinnamon into a bowl.
-2. Add the sugar and mix well.
-3. Add the milk, oil, and vanilla extract to the bowl.
-4. Add the apple sauce to the batter and mix well.
-5. Divide the batter into as many muffin cases as the batter will fill.
-6. Bake at 180°C for about 20 minutes, or until a skewer comes out clean.
-
-</div>

--- a/content/posts/sweet/banana bread/index.md
+++ b/content/posts/sweet/banana bread/index.md
@@ -4,40 +4,34 @@ date: 2025-06-13T11:00:00Z
 draft: false
 tags: ["baked"]
 categories: ["Sweet"]
+prepTime: 15
+cookTime: 60
+servings: "1 loaf"
+ingredients:
+  - "225g all-purpose flour"
+  - "100g spelt flour"
+  - "360g mashed ripe banana (about 3 medium bananas)"
+  - "100ml plant-based milk"
+  - "50ml olive oil"
+  - "20g chicory syrup"
+  - "1/3 lemon, juiced"
+  - "5g baking powder (1 tsp)"
+  - "4g baking soda (½ tsp)"
+  - "5g ground cinnamon (2 tsp)"
+  - "pinch of salt"
+  - "## Optionally add"
+  - "1 banana for decoration, sliced lengthways"
+  - "50g chopped nuts (walnuts or pecans work well)"
+  - "5ml vanilla extract"
+steps:
+  - "Mash the bananas in a bowl until smooth."
+  - "Mix the bananas with the remaining wet ingredients (milk, syrup, oil, lemon juice, vanilla)."
+  - "Add the dry ingredients (flours, baking powder, baking soda, salt, cinnamon) to the wet mixture and stir until just combined. Do not overmix."
+  - "If using, fold in the chopped nuts."
+  - "Preheat the oven to 180°C (350°F) and line a baking tray with parchment paper."
+  - "Pour the batter into the prepared tray and smooth the top."
+  - "If desired, place banana slices on top for decoration."
+  - "Bake for 45 minutes to 1 hour, or until a toothpick inserted into the center comes out clean."
 ---
 
 Need I say more about this classic? Very simple to make, delicious with peanut butter and just a fun time really.
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Baking time: 1 hour
-
-### Ingredients for 1 bred
-- [ ] 225g all-purpose flour
-- [ ] 100g spelt flour
-- [ ] 360g mashed ripe banana (about 3 medium bananas)
-- [ ] 100ml plant-based milk  
-- [ ] 50ml olive oil
-- [ ] 20g chicory syrup
-- [ ] 1/3 lemon, juiced
-- [ ] 5g baking powder (1 tsp)
-- [ ] 4g baking soda (½ tsp)  
-- [ ] 5g Ground Cinnamon (2 tsp)  
-- [ ] pinch of salt  
-#### Optionally add
-- [ ] 1 banana for decoration, sliced lengthways
-- [ ] 50g chopped nuts (walnuts or pecans work well)
-- [ ] 5ml vanilla extract
-
-### Steps
-1. Mash the bananas in a bowl until smooth.
-2. Mix the banans with the remaining wet ingredients (milk, syrup, oil, lemon juice, vanilla).
-3. Add the dry ingredients (flours, baking powder, baking soda, salt, cinnamon) to the wet mixture and stir until just combined. Do not overmix.
-4. If using, fold in the chopped nuts.
-5. Preheat the oven to 180°C (350°F) and line a baking tray with parchment paper.
-6. Pour the batter into the prepared tray and smooth the top.
-7. If desired, place banana slices on top for decoration.
-8. Bake for 45m-1h, or until a toothpick inserted into the center comes out clean.
-
-</div>

--- a/content/posts/sweet/brownies/index.md
+++ b/content/posts/sweet/brownies/index.md
@@ -4,36 +4,30 @@ date: 2023-01-27T12:45:00Z
 draft: false
 tags: ["baked", "chocolate"]
 categories: ["Sweet"]
+prepTime: 10
+cookTime: 30
+servings: "1 tray"
+ingredients:
+  - "200g all purpose flour"
+  - "100g melted butter or coconut oil"
+  - "200ml plant-based milk"
+  - "100g sugar"
+  - "1.5 tsp vanilla"
+  - "100g chocolate"
+  - "40g cocoa powder"
+  - "1 small shot of espresso"
+  - "7g baking powder"
+  - "pinch of salt"
+steps:
+  - "Melt the butter/coconut oil (I used a 50/50 mix) on a double boiler with the vanilla."
+  - "Add your sugar and whisk. Then add the milk and continue whisking."
+  - "In another bowl sift your flour, cocoa powder, baking powder and salt."
+  - "Add the wet ingredients to the dry ingredients and mix until combined."
+  - "Add the espresso and mix again. The batter should just start to stick to the mixing spoon. If your batter is runny, add a bit more flour."
+  - "On a cutting board chop the chocolate into small pieces and fold into the batter."
+  - "Pour the batter in a lined baking tray and bake at 180°C for about 30 minutes, or until a skewer comes out clean."
 ---
 
-I am always in a mood for brownies! I had to tweak a bunch of recipes to get them not to be 50% sugar, which I can't stand (how can Americans do this?). 
+I am always in a mood for brownies! I had to tweak a bunch of recipes to get them not to be 50% sugar, which I can't stand (how can Americans do this?).
 They are very chocolatey, the espresso is mandatory. It is a good idea to use high quality chocolate, because it is dispersed throughout the batter. You may also use chocolate chips. Additionally, you can add some nuts into the batter.
 I also added a bit of coconut oil to the mix, which I think makes them smell nicer.
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 30 minutes
-
-### Ingredients for 1 tray
-- [ ] 200g All Purpose Flour
-- [ ] 100g melted butter/coconut oil
-- [ ] 200ml plant-based milk
-- [ ] 100g sugar
-- [ ] 1.5 tsp vanilla
-- [ ] 100g chocolate
-- [ ] 40g cocoa powder
-- [ ] 1 small shot of espresso
-- [ ] 7g baking powder
-- [ ] pinch of salt
-
-### Steps
-1. Melt the butter/coconut oil (I used a 50/50 mix) on a double boiler with the vanilla.
-2. Add your sugar and whisk. Then add the milk and continue whisking.
-3. In another bowl sift your flour, cocoa powder, baking powder and salt.
-4. Add the wet ingredients to the dry ingredients and mix until combined.
-5. Add the espresso and mix again. The batter should just start to stick to the mixing spoon. If your batter is runny, add a bit more flour.
-6. On a cutting board chop the chocolate into small pieces and fold into the batter.
-7. Pour the batter in a lined baking tray and bake at 180°C for about 30 minutes, or until a skewer comes out clean.
-
-</div>

--- a/content/posts/sweet/bundt cake/index.md
+++ b/content/posts/sweet/bundt cake/index.md
@@ -4,10 +4,33 @@ date: 2023-10-17T00:00:00Z
 draft: false
 tags: ["czech", "baked", "chocolate"]
 categories: ["Sweet"]
+prepTime: 15
+cookTime: 45
+servings: "1 bundt cake"
+ingredients:
+  - "320g all purpose flour"
+  - "150g white sugar"
+  - "200g vegan yoghurt"
+  - "100ml plant-based milk"
+  - "2 tablespoons baking powder"
+  - "1 tablespoon baking soda"
+  - "120g neutral oil"
+  - "juice of 1/2 lemon or a splash of vinegar"
+  - "15g cocoa powder"
+  - "## Optionally add"
+  - "confectioners' sugar to decorate"
+steps:
+  - "Preheat the oven to 180°C."
+  - "Mix the dry ingredients in a bowl (flour, sugar, baking powder, baking soda)."
+  - "Add the wet ingredients (yoghurt, milk, oil, lemon juice) to a separate bowl and mix."
+  - "Sift the dry ingredients into the wet ingredients and mix until combined."
+  - "Pour about half of the batter into a separate bowl and mix in the cocoa powder."
+  - "Grease a bundt cake form with oil, add some flour to coat the oil and pour in the batter alternating between the white and the chocolate batter in random patterns."
+  - "Take a skewer and swirl it through the batter to create a marble effect."
+  - "Bake for 45 minutes or until a skewer inserted into the cake comes out clean (I would start to watch it after ~35 minutes)."
 ---
 
-In my inevitable descent into becoming a housewife I have turned to the humble marble bundt cake. It's a fairy typical dessert to eat in the Czech Republic and I haven't had it in years. Hence, I present a recipe for this delicious staple of the mundane Sunday family occasion. Loosely inspired by [this recipe](https://web.archive.org/web/20230401104615/https://plantifulbakery.com/cs/vegan-mramorova-babovka/).
-
+In my inevitable descent into becoming a housewife I have turned to the humble marble bundt cake. It's a fairly typical dessert to eat in the Czech Republic and I haven't had it in years. Hence, I present a recipe for this delicious staple of the mundane Sunday family occasion. Loosely inspired by [this recipe](https://web.archive.org/web/20230401104615/https://plantifulbakery.com/cs/vegan-mramorova-babovka/).
 
 <div class="image-split">
 
@@ -15,34 +38,4 @@ In my inevitable descent into becoming a housewife I have turned to the humble m
 ![](marble.png)
 
 <span class="caption">Final result - Marble effect</span>
-</div>
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Cooking time: 45 minutes
-
-### Ingredients for 1 bundt cake
-- [ ] 320g all purpose flour
-- [ ] 150g white sugar (yeah it's a lot)
-- [ ] 200g vegan yoghurt
-- [ ] 100ml plant-based milk
-- [ ] 2 tablespoons baking powder
-- [ ] 1 tablespoon baking soda
-- [ ] 120g neutral oil
-- [ ] juice of 1/2 lemon / vinegar
-- [ ] 15g cocoa powder
-#### Optionally add
-- [ ] confectioners' sugar to decorate
-
-### Steps
-1. Preheat the oven to 180°C
-2. Mix the dry ingredients in a bowl (flour, sugar, baking powder, baking soda)
-3. Add the wet ingredients (yoghurt, milk, oil, lemon juice) to a separate bowl and mix
-4. Sift the dry ingredients into the wet ingredients and mix until combined
-5. Pour about half of the batter into a separate bowl and mix in the cocoa powder
-6. Grease a bundt cake form with oil, add some flour to coat the oil and pour in the batter alternating between the white and the chocolate batter in random patterns
-7. Take a skewer and swirl it through the batter to create a marble effect
-8. Bake for 45 minutes or until a skewer inserted into the cake comes out clean (I would start to watch it after ~35 minutes)
-
 </div>

--- a/content/posts/sweet/carrot-muffins/index.md
+++ b/content/posts/sweet/carrot-muffins/index.md
@@ -4,6 +4,33 @@ date: 2024-03-22T12:00:00Z
 draft: false
 tags: ["baked", "muffins", "simple"]
 categories: ["Sweet"]
+prepTime: 20
+cookTime: 45
+servings: "7 muffins"
+ingredients:
+  - "180ml non-dairy milk"
+  - "1 tbsp ground flaxseed"
+  - "50g white whole wheat flour"
+  - "100g white wheat flour"
+  - "100g light brown sugar"
+  - "1 tsp baking powder"
+  - "1/2 tsp baking soda"
+  - "1/2 tsp fine sea salt"
+  - "1.5 tsp ground cinnamon"
+  - "1/2 tsp ground nutmeg"
+  - "35g neutral oil (sunflower or similar)"
+  - "1 finely grated apple (~120g)"
+  - "180g shredded carrot"
+steps:
+  - "Sift the flour, baking powder, baking soda, salt, cinnamon, and nutmeg into a bowl."
+  - "In a separate bowl, mix the milk and flax and let sit for a few minutes."
+  - "Add the sugar and oil to the milk mixture and whisk until combined."
+  - "Add the grated apple and carrot to the wet ingredients and mix."
+  - "Add the dry ingredients to the wet ingredients and mix until just combined."
+  - "Preheat the oven to 180°C and line a muffin tin with paper liners."
+  - "Fill the liners to the top with the batter."
+  - "Bake for 45 minutes or until a skewer inserted into the muffins comes out clean."
+  - "Let cool in the tin for 5 minutes, then transfer to a wire rack to cool completely."
 ---
 
 As the self-proclaimed muffin expert I am, I present to you a very easy to follow recipe for carrot muffins. They are very filling actually and delicious. Even though, to me, there's just something about carrot cake and muffins that feels odd, but it actually works pretty well.
@@ -11,37 +38,3 @@ As the self-proclaimed muffin expert I am, I present to you a very easy to follo
 I don't think coconut oil would work in this, but you're free to try. Especially if using refined coconut oil, it might be fine. I used sunflower oil and it worked well. Once again a conglomerate of various recipes I found online, reduced sugar and low-ish fat. But you can't make muffins healthy!
 
 The batter will be slightly runny and that's completely OK. The muffins will rise and be fluffy. This can make about 7 muffins if you fill the cases to the top.
-
-<div class="recipe" id="recipe">
-Prep time: 20 minutes
-
-Cooking time: 45 minutes
-
-### Ingredients for 7 muffins
-- [ ] 180ml non-dairy milk
-- [ ] 1 tbsp ground flaxseed
-- [ ] 50g white whole wheat flour
-- [ ] 100g white wheat flour (yes we're mixing!)
-- [ ] 100g light brown sugar
-- [ ] 1 tsp baking powder
-- [ ] 1/2 tsp baking soda
-- [ ] 1/22 tsp fine sea salt
-- [ ] 1 1/2 tsp ground cinnamon
-- [ ] 1/2 tsp ground nutmeg
-- [ ] 35g neutral oil (sunflower or similar)
-- [ ] 1 finely grated apple (~120g)
-- [ ] 180g shredded carrot
-
-
-### Steps
-1. Sift the flour, baking powder, baking soda, salt, cinnamon, and nutmeg into a bowl.
-2. In a separate bowl, mix the milk and flax and let sit for a few minutes.
-3. Add the sugar and oil to the milk mixture and whisk until combined.
-4. Add the grated apple and carrot to the wet ingredients and mix.
-5. Add the dry ingredients to the wet ingredients and mix until just combined.
-6. Preheat the oven to 180°C and line a muffin tin with paper liners.
-7. Fill the liners to the top with the batter.
-8. Bake for 45 minutes or until a skewer inserted into the muffins comes out clean.
-9. Let cool in the tin for 5 minutes, then transfer to a wire rack to cool completely.
-
-</div>

--- a/content/posts/sweet/chocolate-muffins/index.md
+++ b/content/posts/sweet/chocolate-muffins/index.md
@@ -4,34 +4,28 @@ date: 2023-01-22T23:11:13Z
 draft: false
 tags: ["baked", "muffins", "chocolate"]
 categories: ["Sweet"]
+prepTime: 10
+cookTime: 20
+servings: "1 tray"
+ingredients:
+  - "300g all purpose flour"
+  - "60g brown sugar"
+  - "7g baking powder"
+  - "pinch of salt"
+  - "250ml plant based milk"
+  - "1/2 cup of chocolate chips"
+  - "150g apple sauce"
+  - "shot of espresso"
+  - "60g melted coconut oil, or other neutral oil"
+  - "45g cocoa powder"
+steps:
+  - "Sift the flour, baking powder, salt and cocoa powder into a bowl."
+  - "Add the sugar and mix."
+  - "Add the milk, apple sauce, espresso and oil and mix until combined. The batter should be slightly runny. If it's too thick, add a bit more milk or applesauce."
+  - "Add the chocolate chips and mix."
+  - "Pour into muffin tins and bake at 180°C for 20 minutes, or until a skewer comes out clean."
 ---
 
-Another muffin recipe? No complaining, these are delicious! Similar to the apple muffins, these are 
+Another muffin recipe? No complaining, these are delicious! Similar to the apple muffins, these are
 a bit more on the sweet side. This recipe has apple sauce in it, which makes it a bit more moist
 and gives us an excuse not to put in as much sugar.
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 20 minutes
-
-### Ingredients for 1 tray
-- [ ] 300g All Purpose Flour
-- [ ] 60g Brown Sugar
-- [ ] 7g Baking Powder
-- [ ] Pinch of Salt
-- [ ] 250ml plant based milk
-- [ ] 1/2 cup of chocolate chips
-- [ ] 150g apple sauce
-- [ ] shot of espresso
-- [ ] 60g melted coconut oil, or other neutral oil
-- [ ] 45g cocoa powder
-
-### Steps
-1. Sift the flour, baking powder, salt and cocoa powder into a bowl.
-2. Add the sugar and mix.
-3. Add the milk, apple sauce, espresso and oil and mix until combined. The batter should be slightly runny. If it's too thick, add a bit more milk or applesauce.
-4. Add the chocolate chips and mix.
-5. Pour into muffin tins and bake at 180C for 20 minutes, or until a skewer comes out clean.
-
-</div>

--- a/content/posts/sweet/christmas-truffles/index.md
+++ b/content/posts/sweet/christmas-truffles/index.md
@@ -4,10 +4,27 @@ date: 2022-12-29T12:41:27+01:00
 draft: false
 tags: ["christmas", "party-food"]
 categories: ["Sweet"]
+prepTime: 5
+cookTime: 10
+servings: "a whole bunch"
+ingredients:
+  - "100g walnuts"
+  - "100g dates, pitted"
+  - "15g cocoa powder"
+  - "30g grated coconut"
+  - "1/2 espresso shot to boost the chocolate flavor"
+  - "obligatory pinch of salt"
+  - "## For the coating"
+  - "30g cocoa powder, or grated coconut"
+steps:
+  - "Add all the ingredients to a food processor."
+  - "Blend until no large chunks remain."
+  - "Wet your hands and roll into balls."
+  - "Roll the balls in the coating of your choice."
 ---
 
 Christmas! We all know how dire the vegan Christmas
-sweets situation is. 
+sweets situation is.
 These balls are chewy, chocolatey, nutty and oh so good!
 
 Ingredients intentionally vague, because nobody ever has enough walnuts.
@@ -20,30 +37,4 @@ They keep well in the fridge for a few weeks.
 ![](balls1.jpg)
 
 <span class="caption">Christmas balls</span>
-</div>
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 10 minutes
-
-### Ingredients for a whole bunch of 'em
-- [ ] 100g walnuts
-- [ ] 100g dates, pitted
-- [ ] 15g cocoa powder
-- [ ] 30g grated coconut
-- [ ] 1/2 espresso shot to boost the chocolate flavor
-- [ ] obligatory pinch of salt
-#### For the coating
-- [ ] 30g cocoa powder, or grated coconut
-
-### Steps
-1. Add all the ingredients to a food processor
-2. Blend until no large chunks remain
-3. Wet your hands and roll into balls
-4. Roll the balls in the coating of your choice
-
-![](/christmas-balls/balls1.jpg)
-
-
 </div>

--- a/content/posts/sweet/cinnamon-rolls/index.md
+++ b/content/posts/sweet/cinnamon-rolls/index.md
@@ -4,42 +4,35 @@ date: 2023-02-14T12:00:00Z
 draft: false
 tags: ["baked", "yeast", "cinnamon", "satisfying"]
 categories: ["Sweet"]
+prepTime: 45
+cookTime: 30
+servings: "12 rolls"
+ingredients:
+  - "700g all purpose flour"
+  - "115g vegan butter"
+  - "50g sugar (20g white sugar, 30g brown sugar)"
+  - "1 teaspoon salt"
+  - "480ml plant based milk"
+  - "1 packet dry yeast"
+  - "## For the filling"
+  - "175g vegan butter"
+  - "150g brown granulated sugar"
+  - "3 tablespoons cinnamon"
+steps:
+  - "In a large bowl, mix the melted butter, sugar and milk. Add the yeast and mix."
+  - "Add the flour and mix until a dough forms. Add in the salt."
+  - "Cover the bowl with a towel and let it rest for 45 minutes to 1 hour."
+  - "After the dough has rested add the remaining 100g of flour and knead the dough for a minute or two, until it forms a smooth ball."
+  - "Transfer the dough to a lightly floured surface and roll it out into a rectangle. Spread the butter over the dough, then sprinkle the sugar and cinnamon over the butter."
+  - "Roll the dough up tightly, starting from the long side. Cut the dough into 12 or so equal pieces."
+  - "Place the rolls in a lined baking dish, cover with a towel and let them rise for 15 minutes."
+  - "Preheat the oven to 180°C."
+  - "Bake the rolls for 25-30 minutes, or until they are golden brown."
+  - "Frosting is overrated. :)"
 ---
 
 As it stands I try to publish recipes that I have come up with, or at least significantly altered. This time, however, a recipe is so
-good I just had to share it! It is a Tasty recipe - [https://tasty.co/recipe...](https://tasty.co/recipe/the-best-ever-vegan-cinnamon-rolls), with slight measurements tweaks.
+good I just had to share it! It is a Tasty recipe — [https://tasty.co/recipe...](https://tasty.co/recipe/the-best-ever-vegan-cinnamon-rolls), with slight measurement tweaks.
 
 We have made it on Valentine's Day according to the recipe, however a sugar reduction has not suited this recipe well. I would recommend using the full amount of sugar.
 I have eaten these for breakfast, lunch and dinner, and they are just so good 😭... I hope you enjoy them as much as we did!
-
-
-<div class="recipe" id="recipe">
-Prep time: 45 minutes
-
-Cooking time: 30 minutes
-
-### Ingredients for 12 rolls
-- [ ] 700g All Purpose Flour
-- [ ] 115g vegan butter
-- [ ] 50g sugar (20g white sugar, 30g brown sugar)
-- [ ] 1 teaspoon salt
-- [ ] 480ml plant based milk
-- [ ] 1 packet dry yeast
-
-#### For the filling
-- [ ] 175g vegan butter
-- [ ] 150g brown granulated sugar
-- [ ] 3 tablespoons cinnamon
-
-### Steps
-1. In a large bowl, mix the melted butter, sugar and milk. Add the yeast and mix.
-2. Add the flour and mix until a dough forms. Add in the salt. 
-3. Cover the bowl with a towel and let it rest for 45 minutes to 1 hour.
-4. After the dough has rested add the remaining 100g of flour and knead the dough for a minute or two, until it forms a smooth ball.
-5. Transfer the dough to a lightly floured surface and roll it out into a rectangle. Spread the butter over the dough, then sprinkle the sugar and cinnamon over the butter.
-6. Roll the dough up tightly, starting from the long side. Cut the dough into 12 or so equal pieces.
-7. Place the rolls in a lined baking dish, cover with a towel and let them rise for 15 minutes.
-8. Preheat the oven to 180°C.
-9. Bake the rolls for 25-30 minutes, or until they are golden brown.
-10. Frosting is overrated. :)
-</div>

--- a/content/posts/sweet/cookies/index.md
+++ b/content/posts/sweet/cookies/index.md
@@ -4,36 +4,30 @@ date: 2023-02-01T12:00:00Z
 draft: false
 tags: ["baked", "chocolate", "cookies"]
 categories: ["Sweet"]
+prepTime: 10
+cookTime: 20
+servings: "1 tray"
+ingredients:
+  - "250g all purpose flour"
+  - "100g fine oats"
+  - "80g plant-based milk"
+  - "1 teaspoon baking powder"
+  - "1/2 teaspoon baking soda"
+  - "1/2 teaspoon salt"
+  - "80g coconut oil"
+  - "80g sugar"
+  - "chocolate chips — as many as you like!"
+steps:
+  - "Preheat the oven to 180°C."
+  - "Sift the flour, baking powder, baking soda and salt into a bowl."
+  - "Add the oats and mix."
+  - "Add the coconut oil, melted together with sugar and mix."
+  - "Add the milk and mix."
+  - "Fold in your chocolate chips."
+  - "Form small balls (about 1 tablespoon scoop's worth) and place on a baking sheet."
+  - "Bake for 15+ minutes. The cookies should be golden brown on the edges and a skewer should come out clean when inserted in the middle. Do not overbake!"
 ---
 
 Continuing on my little sweet baking spree, I could never get cookies to taste nice until my girlfriend found a recipe that works. With the usual sugar reduction and switch to plant-based milk, these cookies are oh so good!
 
 It is important not to overbake them as they will become very dry and hard (I sadly know this from experience, my cookies used to be real tooth breakers).
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 20 minutes
-
-### Ingredients for 1 tray
-- [ ] 250g All Purpose Flour
-- [ ] 100g fine oats
-- [ ] 80g plant-based milk
-- [ ] 1 teaspoon baking powder
-- [ ] 1/2 teaspoon baking soda
-- [ ] 1/2 teaspoon salt
-- [ ] 80g coconut oil
-- [ ] 80g sugar
-- [ ] chocolate chips. As many as you like!
-
-### Steps
-1. Preheat the oven to 180°C.
-2. Sift the flour, baking powder, baking soda and salt into a bowl.
-3. Add the oats and mix.
-4. Add the coconut oil, melted together with sugar and mix.
-5. Add the milk and mix.
-6. Fold in your chocolate chips.
-7. Form small balls (about 1 tablespoon scoop's worth) and place on a baking sheet.
-8. Bake for 15+ minutes. The cookies should be golden brown on the edges and a skewer should come out clean when inserted in the middle. Do not overbake!
-
-</div>

--- a/content/posts/sweet/pancakes/index.md
+++ b/content/posts/sweet/pancakes/index.md
@@ -4,34 +4,27 @@ date: 2023-06-02T00:00:13Z
 draft: false
 tags: ["quick", "breakfast"]
 categories: ["Sweet"]
+prepTime: 5
+cookTime: 10
+servings: "4 pancakes"
+ingredients:
+  - "100g all purpose flour"
+  - "2g salt"
+  - "125ml milk"
+  - "3.5g baking powder"
+  - "1 large banana"
+  - "2 tablespoons oil or vegan butter to fry on"
+  - "## Optionally add"
+  - "maple syrup topping"
+  - "strawberries or other fruit"
+steps:
+  - "Mash the banana in a bowl."
+  - "Sift the flour and baking powder into the bowl."
+  - "Add the milk to the bowl and carefully mix until smooth."
+  - "The batter should be a little runny, but not a viscous liquid."
+  - "Add a tablespoon of oil into a heated pan and pour in the batter."
+  - "Cook for 2-3 minutes on each side, or until golden brown."
+  - "Serve with maple syrup and fruit."
 ---
 
 This is a sister recipe to my [waffles](/posts/sweet/waffles/). It's your shortest path to delicious pancakes, made from a pretty versatile batter. It's a great way to use up leftover bananas and an even better way to start your day.
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 10 minutes
-
-### Ingredients for 4 medium pancakes
-- [ ] 100g all purpose flour
-- [ ] 2g salt
-- [ ] 125ml milk
-- [ ] 3.5g baking powder
-- [ ] 1 large banana
-- [ ] 2 tablespoons oil/vegan butter to fry on
-
-#### Optionally add
-- [ ] maple syrup topping
-- [ ] strawberries or other fruit
-
-### Steps
-1. Mash the banana in a bowl.
-2. Sift the flour and baking powder into the bowl.
-3. Add the milk to the bowl and carefully mix until smooth.
-4. The batter should be a little runny, but not a viscous liquid.
-5. Add a tablespoon of oil into a heated pan and pour in the batter.
-6. Cook for 2-3 minutes on each side, or until golden brown.
-7. Serve with maple syrup and fruit.
-
-</div>

--- a/content/posts/sweet/peach cake/index.md
+++ b/content/posts/sweet/peach cake/index.md
@@ -4,9 +4,43 @@ date: 2025-06-13T12:00:00Z
 draft: false
 tags: ["baked", "cake", "chocolate"]
 categories: ["Sweet"]
+prepTime: 15
+cookTime: 60
+servings: "1 cake"
+ingredients:
+  - "150g all-purpose flour"
+  - "100g butter + 40g butter"
+  - "25g chicory syrup"
+  - "50g peanut butter"
+  - "4-5 peaches"
+  - "5g baking powder (1 tsp)"
+  - "150ml oat milk"
+  - "1 apple, grated"
+  - "1/2 cup espresso (or strong coffee)"
+  - "3 tablespoons cocoa powder"
+  - "juice of 1/3 lemon for the baking soda"
+  - "1/2 teaspoon baking soda"
+  - "1 tablespoon cinnamon"
+  - "pinch of salt"
+  - "## Optionally add"
+  - "very finely chopped nuts for topping (I used walnuts)"
+  - "coconut flakes for topping"
+steps:
+  - "Preheat the oven to 175°C. Line a 9-inch round cake pan with parchment paper."
+  - "In a large skillet, melt 100g of butter over medium heat. Cook it while stirring with a rubber spatula until it turns a deep golden brown, about 5-7 minutes. Remove from heat, pour it into a bowl, and let it cool slightly."
+  - "In the same, now empty, pan, add the 40g butter, chicory syrup, and peanut butter. Stir until melted and well combined."
+  - "Pour mixture into the prepared cake pan, spreading it evenly. It will be a bit runny, this is fine."
+  - "Cut peaches into slices and arrange on top of the base mixture in a circular pattern. The bigger you go the better — the large peach chunks are the best part."
+  - "In a mixing bowl, whisk together the flour, baking powder, and salt. Add cocoa powder and mix well."
+  - "Grate an apple into the brown butter mixture, add milk, espresso, and mix until well combined."
+  - "Add the dry ingredients to the wet mixture and stir until just combined. Do not overmix."
+  - "Pour the batter over the peaches in the cake pan, smoothing the top with a spatula."
+  - "Bake in the preheated oven for 30-35 minutes, or until a toothpick inserted into the center comes out clean."
+  - "Let the cake cool in the pan for 10 minutes, then invert onto a serving plate. Remove the parchment paper."
+  - "Serve warm or at room temperature, optionally with whipped cream on the side."
 ---
 
-This is cake that is baked with peaches at the bottom, and then inverted after baking. Every square centimeter of this cake hits you with a new flavor, the mixture of chocolate, peach and nuts is just unbelievable. Also, no sugar added here. If you want, you can even skip the chicory - it was still overly sweet for me, but I wanted to try it out :) Enjoy!
+This is a cake that is baked with peaches at the bottom, and then inverted after baking. Every square centimeter of this cake hits you with a new flavor — the mixture of chocolate, peach and nuts is just unbelievable. Also, no sugar added here. If you want, you can even skip the chicory — it was still overly sweet for me, but I wanted to try it out :) Enjoy!
 
 <div class="image-split">
 
@@ -23,45 +57,4 @@ Here you can see how to arrange it. It might look like it will burn, but trust t
 ![](2.jpg)
 
 <span class="caption">Base layer - Peach arrangement</span>
-</div>
-
-<div class="recipe" id="recipe">
-Prep time: 15 minutes
-
-Baking time: 1 hour
-
-### Ingredients for 1 of em
-- [ ] 150g All-Purpose Flour
-- [ ] 100g butter + 40g buttter
-- [ ] 25g chicory syrup
-- [ ] 50g peanut butter
-- [ ] 4-5 peaches
-- [ ] 5g baking powder (1 tsp)
-- [ ] 150ml oat milk
-- [ ] 1 apple, grated
-- [ ] 1/2 cup espresso (or strong coffee)
-- [ ] 3 tablespoons cocoa powder
-- [ ] juice of 1/3 lemon for the soda
-- [ ] 1/2 teaspoon baking soda
-- [ ] 1 tablespoon cinnamon
-- [ ] pinch of salt
-
-#### Optionally add
-- [ ] very finely chopped nuts for topping (I used walnuts)
-- [ ] coconut flakes for topping
-
-### Steps
-1. Preheat the oven to 175°C. Line a 9-inch round cake pan with parchment paper.
-2. In a large skillet, melt 100g of butter over medium heat. Cook it while stirring with a rubber spatula until it turns a deep golden brown, about 5-7 minutes. Remove from heat, pour it into a bowl, and let it cool slightly.
-3. In the same, now empty, pan, add the 40g butter, chicory syrup, and peanut butter. Stir until melted and well combined.
-4. Pour mixture into the prepared cake pan, spreading it evenly. It will be a bit runny, this is fine.
-5. Cut peaches into slices as seen in the image above. The bigger you go the better (the large peache chunks are the best part). Arrange the peach slices on top of the base mixture in a circular pattern.
-6. In a mixing bowl, whisk together the flour, baking powder, and salt. Add cocoa powder and mix well.
-7. Grate an apple into the brown butter mixture, add milk, espresso, and mix until well combined.
-8. Add the dry ingredients to the wet mixture and stir until just combined. Do not overmix.
-9. Pour the batter over the peaches in the cake pan, smoothing the top with a spatula.
-10. Bake in the preheated oven for 30-35 minutes, or until a toothpick inserted into the center comes out clean.
-11. Let the cake cool in the pan for 10 minutes, then invert onto a serving plate. Remove the parchment paper.
-12. Serve warm or at room temperature, optionally with whipped cream on the side.
-
 </div>

--- a/content/posts/sweet/peanut butter banana cookies/index.md
+++ b/content/posts/sweet/peanut butter banana cookies/index.md
@@ -4,32 +4,24 @@ date: 2025-06-20T21:00:00+01:00
 draft: false
 tags: ["baked", "sugar-free", "cookies", "chocolate", "banana"]
 categories: ["Sweet"]
+prepTime: 10
+cookTime: 15
+ingredients:
+  - "2 bananas + 1 for topping (very ripe)"
+  - "100g peanut butter"
+  - "20g chicory syrup"
+  - "180g oat flour"
+  - "60g chocolate chips"
+  - "1 tsp cinnamon"
+  - "1 tsp baking powder"
+steps:
+  - "Preheat your oven to 180°C and line your baking tray with parchment paper."
+  - "In a bowl, mash up the 2 bananas, add the peanut butter and chicory syrup and mix it well until you have a brownish paste."
+  - "In a separate bowl, combine the flour, baking powder and cinnamon."
+  - "Add the wet to the dry gradually, also add in the chocolate chips. Combine until you have a big ball of cookie dough."
+  - "Take an ice cream scooper (or just use your hands) and make golf ball sized balls onto your tray and flatten them a bit — they won't really expand much."
+  - "Add a round slice of banana onto each cookie and push it in a bit."
+  - "Put the cookies in the oven for 10-15 minutes or until they're a bit golden on the top."
 ---
 
 I mean if you like bananas and peanut butter, this is the cookie for you really. And the fact that they have no added sugar and you still haven't made them is just not acceptable :)
-
-<div class="recipe" id="recipe">
-Prep time: 10 minutes
-
-Cooking time: 15 minutes
-
-### Ingredients
-- [ ] 2 Bananas + 1 for topping (very ripe)
-- [ ] 100 g peanut butter
-- [ ] 20 g chicory syrup
-- [ ] 180 g oat flour
-- [ ] 60 g chocolate chips
-- [ ] 1 tsp cinnamon
-- [ ] 1 tsp baking powder
-
-### Steps
-
-1. Preheat your oven to 180˚C and line your baking tray with parchment paper.
-2. In a bowl, mash up the 2 bananas, add the peanut butter and chicory syrup and mix it well until you have a brownish paste.
-3. In a separate bowl, combine the flour, baking powder and cinnamon.
-4. Add the wet to the dry gradually, also add in the chocolate chips. Combine until you have a big ball of cookie dough.
-5. Take an icecream scooper (or if you're built different just use your hands) and make golf ball sized balls onto your tray and flatten them a bit because they won´t really expand much.
-6. Add a round slice of banana onto each cookie and push it in a bit.
-7. Put the cookies in the oven for 10-15 minutes or until they're a bit golden on the top.
-
-</div>

--- a/content/posts/sweet/vegan-frgal/index.md
+++ b/content/posts/sweet/vegan-frgal/index.md
@@ -2,75 +2,70 @@
 title: "Vegan frgál"
 date: 2024-04-05T00:00:00Z
 draft: false
-tags: ["czech", "baked", 'pie']
+tags: ["czech", "baked", "pie"]
 categories: ["Sweet"]
+prepTime: 30
+cookTime: 30
+servings: "1 frgál"
+ingredients:
+  - "## Dough"
+  - "130g flour"
+  - "20g icing sugar"
+  - "1 packet (7g) of instant yeast"
+  - "1/2 tsp salt"
+  - "60g soy milk"
+  - "35g vegan butter"
+  - "1/2 tsp lemon zest"
+  - "## Crumb topping (~'drobenka')"
+  - "40g vegan butter"
+  - "40g icing sugar"
+  - "75g flour"
+steps:
+  - "Add the yeast to all the milk (warm, but not hot) and let it sit for 5 minutes."
+  - "Mix all the dry ingredients for the dough in a bowl."
+  - "Add the milk with the yeast and the melted butter to the dry ingredients."
+  - "Mix and then knead the dough until it's smooth and let it rest for 30 minutes."
+  - "Preheat the oven to 180°C."
+  - "Roll out the dough to a circle on a flour-dusted surface."
+  - "Spread the filling evenly on the dough."
+  - "Mix all the ingredients for the crumb topping and sprinkle it on top of the filling."
+  - "Bake for 30 minutes."
+  - "Let it cool down before cutting it into slices."
 ---
 
 A traditional Czech pie that is close to my heart. It's not as hard to make as it may seem and it's quite a fun recipe. Sooo simple to make vegan too!
 
-There is a variety of different fillings you can use, in this recipe I will show you how to make a plum jam version and a pear version. However, there is a hoast of other possible options and you can find them readily online. 
+There is a variety of different fillings you can use — in this recipe I will show you how to make a plum jam version and a pear version. However, there is a host of other possible options and you can find them readily online.
 
-<i>Tip: The dough can be quite sticky, so make sure to flour your hands and the surface you are working on.</i>
+*Tip: The dough can be quite sticky, so make sure to flour your hands and the surface you are working on.*
 
-<i>Tip: Homemade jams vary in thickness and sweetness, adjust accordingly.</i>
-
-<div class="recipe" id="recipe">
-Prep time: 30 minutes
-
-Cooking time: 30 minutes
-
-### Ingredients for 1 frgál
-#### Dough
-- [ ] 130g flour
-- [ ] 20g icing sugar
-- [ ] 1 packet (7g) of instant yeast
-- [ ] 1/2 tsp salt
-- [ ] 60g soy milk 
-- [ ] 35g vegan butter
-- [ ] 1/2 tsp lemon zest
-
-#### Crumb topping (~'drobenka')
-- [ ] 40g vegan butter
-- [ ] 40g icing sugar
-- [ ] 75g flour
-
-### Steps
-1. Add the yeast to all the milk (warm, but not hot) and let it sit for 5 minutes.
-2. Mix all the dry ingredients for the dough in a bowl.
-3. Add the milk with the yeast and the melted butter to the dry ingredients.
-4. Mix and then knead the dough until it's smooth and let it rest for 30 minutes.
-5. Preheat the oven to 180°C.
-6. Roll out the dough to a circle on a flour-dusted surface.
-7. Spead the filling evenly on the dough.
-8. Mix all the ingredients for the crumb topping and sprinkle it on top of the filling.
-9. Bake for 30 minutes.
-10. Let it cool down before cutting it into slices.
-
-</div>
+*Tip: Homemade jams vary in thickness and sweetness, adjust accordingly.*
 
 <div class="recipe">
-<h3 class="title">Plum jam filling (1 frgál)</h3>
+<h3>Plum jam filling (1 frgál)</h3>
+
 Prep time: 5 minutes
 
-- [ ] 350g plum jam
-- [ ] 1 packet vanilla sugar
-- [ ] ~15g breadcrumbs
-- [ ] optionally a splash or rum
+- 350g plum jam
+- 1 packet vanilla sugar
+- ~15g breadcrumbs
+- optionally a splash of rum
 
 Mix the jam with the vanilla sugar and rum. The filling should be only slightly runny and should spread without moving. If it's too runny, add breadcrumbs until it thickens.
 
 </div>
 
 <div class="recipe">
-<h3 class="title">Pear jam filling (1 frgál)</h3>
+<h3>Pear jam filling (1 frgál)</h3>
+
 Prep time: 5 minutes
 
-- [ ] 350g plum jam
-- [ ] 1 packet vanilla sugar
-- [ ] ~15g breadcrumbs
-- [ ] optionally a splash or rum
-- [ ] 1 tablespoon cinnamon
-- [ ] 1 tablespoon ground star anise
+- 350g pear jam
+- 1 packet vanilla sugar
+- ~15g breadcrumbs
+- optionally a splash of rum
+- 1 tablespoon cinnamon
+- 1 tablespoon ground star anise
 
 Mix the jam with the vanilla sugar and rum. The filling should be only slightly runny and should spread without moving. If it's too runny, add breadcrumbs until it thickens.
 

--- a/content/posts/sweet/waffles/index.md
+++ b/content/posts/sweet/waffles/index.md
@@ -4,6 +4,24 @@ date: 2023-01-19T23:11:13Z
 draft: false
 tags: ["quick", "breakfast"]
 categories: ["Sweet"]
+prepTime: 5
+cookTime: 10
+servings: "5 waffles"
+ingredients:
+  - "120g all purpose flour"
+  - "2g salt"
+  - "200ml milk"
+  - "3.5g baking powder"
+  - "1 large banana"
+  - "14ml oil or vegan butter (optional)"
+steps:
+  - "Mash the banana in a bowl."
+  - "Sift the flour and baking powder into the bowl."
+  - "Add the milk and about a tablespoon of melted oil to the bowl."
+  - "Carefully mix the batter until it is smooth."
+  - "The batter should be a little runny, but not a viscous liquid."
+  - "Divide the remaining oil into 2 batches and add a batch to the waffle iron."
+  - "Pour the batter into the waffle iron and cook until golden brown."
 ---
 
 Who doesn't like a good waffle! This recipe is a great way to start your day. It's quick and easy to make, and it's a great way to use up leftover bananas.
@@ -11,33 +29,7 @@ Who doesn't like a good waffle! This recipe is a great way to start your day. It
 Ideally the bananas should be overripe, the darker the better. The bananas act as a natural sweetener, so you don't need to add any sugar to the batter. The bananas also help to make the waffles nice and fluffy.
 If your bananas aren't quite ripe enough, you can add a tablespoon of sugar.
 If you happen to have no bananas (poor you), about 1/10 of the weight of flour in sugar can be used instead.
-We also add a pinch of salt to balance out the flavor of the batter. 
+We also add a pinch of salt to balance out the flavor of the batter.
 
 This batter can be made without the use of any oil, but it is recommended and will depend on your waffle iron.
 The milk may be substituted for water in dire need.
-
-
-
-<div class="recipe" id="recipe">
-Prep time: 5 minutes
-
-Cooking time: 10 minutes
-
-### Ingredients for 5 waffles
-- [ ] 120g all purpose flour
-- [ ] 2g salt
-- [ ] 200ml milk
-- [ ] 3.5g baking powder
-- [ ] 1 large banana
-- [ ] 14ml oil/vegan butter optional
-
-### Steps
-1. Mash the banana in a bowl.
-2. Sift the flour and baking powder into the bowl.
-3. Add the milk and about a tablespoon of melted oil to the bowl.
-4. Carefully mix the batter until it is smooth.
-5. The batter should be a little runny, but not a viscous liquid.
-6. Divide the remaining oil into 2 batches and add a batch to the waffle iron.
-7. Pour the batter into the waffle iron and cook until golden brown.
-
-</div>

--- a/themes/bean/layouts/_default/single.html
+++ b/themes/bean/layouts/_default/single.html
@@ -23,7 +23,7 @@
                             </p>
                         </span>
                         <p class="dark-gray-text" id="wordcount"> {{ .WordCount }} Words - reading time: {{ math.Round (div (countwords .Content) 180.0) }} minutes. </p>
-                        {{ if .Params.tags }}
+                        {{ if .Params.ingredients }}
                             <a href="#recipe">
                                 <button class="jump-to-recipe">Jump to recipe</button>
                             </a>
@@ -31,7 +31,33 @@
                     </section>
                 </div>
                 <span class="main-content">
-                    {{ replace .Content "disabled" "" | safeHTML }}
+                    {{ .Content | safeHTML }}
+                    {{ if .Params.ingredients }}
+                    <div class="recipe" id="recipe">
+                        <div class="recipe-times">
+                            {{ with .Params.prepTime }}<p><strong>Prep time:</strong> {{ . }} minutes</p>{{ end }}
+                            {{ with .Params.cookTime }}<p><strong>Cook time:</strong> {{ . }} minutes</p>{{ end }}
+                        </div>
+                        <h3>Ingredients{{ with .Params.servings }} for {{ . }}{{ end }}</h3>
+                        <ul>
+                            {{ range .Params.ingredients }}
+                                {{ if strings.HasPrefix . "## " }}
+                                <li class="ingredient-section">{{ strings.TrimPrefix "## " . }}</li>
+                                {{ else }}
+                                <li>{{ . }}</li>
+                                {{ end }}
+                            {{ end }}
+                        </ul>
+                        {{ if .Params.steps }}
+                        <h3>Steps</h3>
+                        <ol>
+                            {{ range .Params.steps }}
+                            <li>{{ . }}</li>
+                            {{ end }}
+                        </ol>
+                        {{ end }}
+                    </div>
+                    {{ end }}
                 </span>
             </article>
         </section>
@@ -67,35 +93,24 @@
         </div>
         <div class="recent-posts">
             {{ range ( where .Site.RegularPages "Type" "posts" | first 5 ) }}
-                <div class="article" onclick="location.href='{{ .RelPermalink }}';">
+                <a class="article" href="{{ .RelPermalink }}">
                     {{ $diff := now.Sub .Lastmod }}
                     {{ if lt $diff.Hours 120 }}
                         <div class="new">NEW</div>
                     {{ end }}
-                        <div class="vertical"><a href="{{ .RelPermalink }}">
-                            {{ with .Resources }}
-                                {{ $image := .GetMatch "{cover.*}" }}
-                                {{ $image := $image.Process "resize 250x" }}
-                                {{ if $image }}
-                                    <div class="cover_image"
-                                            style="background-image: url({{ $image.RelPermalink }});"></div>
-                                {{ end }}
+                    <div class="vertical">
+                        {{ with .Resources }}
+                            {{ $image := .GetMatch "{cover.*}" }}
+                            {{ $image := $image.Process "resize 250x" }}
+                            {{ if $image }}
+                                <div class="cover_image"
+                                        style="background-image: url({{ $image.RelPermalink }});"></div>
                             {{ end }}
-                        </a>
-                        <a href="{{ .RelPermalink }}"><h2>{{ strings.Title .Title }}</h2></a>
-                    </div>
-                    <span>
-                        {{ .Summary | truncate 200 }}
-                        </span>
-                        <span>
-                        {{ if .Truncated }}
-                            <!-- This <div> includes a read more link, but only if the summary is truncated... -->
-                        <!--<div class="bottom-link">
-                            <a href="{{ .RelPermalink }}">Continue reading…</a>
-                        </div>-->
                         {{ end }}
-                        </span>
-                </div>
+                        <h2>{{ strings.Title .Title }}</h2>
+                    </div>
+                    <span>{{ .Summary | truncate 200 }}</span>
+                </a>
             {{ end }}
         </div>
     </div>

--- a/themes/bean/layouts/_default/taxonomy.html
+++ b/themes/bean/layouts/_default/taxonomy.html
@@ -41,32 +41,23 @@
             <h1>{{ $title }}</h1>
             <div class="category">
                 {{ range .Paginator.Pages.ByDate.Reverse }}
-                <span class="article" onclick="location.href='{{ .RelPermalink }}';">
-                        {{ $diff := now.Sub .Lastmod }}
-                        {{ if lt $diff.Hours 120 }}
-                            <div class="new">NEW</div>
-                        {{ end }}
-                        <span><a href="{{ .RelPermalink }}">
-                            {{ with .Resources }}
-                                {{ $image := .GetMatch "{cover.*}" }}
-                                {{ $image := $image.Process "resize 800x" }}
-                                {{ if $image }}
-                                        <div class="cover_image" style="background-image: url({{ $image.RelPermalink }});"></div>
-                                {{ end }}
+                <a class="article" href="{{ .RelPermalink }}">
+                    {{ $diff := now.Sub .Lastmod }}
+                    {{ if lt $diff.Hours 120 }}
+                        <div class="new">NEW</div>
+                    {{ end }}
+                    <span>
+                        {{ with .Resources }}
+                            {{ $image := .GetMatch "{cover.*}" }}
+                            {{ $image := $image.Process "resize 800x" }}
+                            {{ if $image }}
+                                <div class="cover_image" style="background-image: url({{ $image.RelPermalink }});"></div>
                             {{ end }}
-                        </a>
-                        <a href="{{ .RelPermalink }}"><h2>{{ strings.Title .Title }}</h2></a>
-                        {{ .Summary | truncate 200 }}
-                        </span>                        
-                        <span>
-                        {{ if .Truncated }}
-                            <!-- This <div> includes a read more link, but only if the summary is truncated... -->
-                        <!--<div class="bottom-link">
-                            <a href="{{ .RelPermalink }}">Continue reading…</a>
-                        </div>-->
                         {{ end }}
-                        </span>
+                        <h2>{{ strings.Title .Title }}</h2>
+                        {{ .Summary | truncate 200 }}
                     </span>
+                </a>
                 {{ end }}
             </div>
         </div>

--- a/themes/bean/layouts/index.html
+++ b/themes/bean/layouts/index.html
@@ -12,32 +12,23 @@
 
         <div class="category">
             {{ range (.Paginate (.Pages).ByDate.Reverse).Pages | first 6 }}
-                <span class="article" onclick="location.href='{{ .RelPermalink }}';">
+                <a class="article" href="{{ .RelPermalink }}">
                     {{ $diff := now.Sub .Lastmod }}
                     {{ if lt $diff.Hours 120 }}
                         <div class="new">NEW</div>
                     {{ end }}
-                    <span><a href="{{ .RelPermalink }}">
+                    <span>
                         {{ with .Resources }}
                             {{ $image := .GetMatch "{cover.*}" }}
                             {{ $image := $image.Process "resize 800x" }}
                             {{ if $image }}
-                                    <div class="cover_image" style="background-image: url({{ $image.RelPermalink }});"></div>
+                                <div class="cover_image" style="background-image: url({{ $image.RelPermalink }});"></div>
                             {{ end }}
                         {{ end }}
-                    </a>
-                    <a href="{{ .RelPermalink }}"><h2>{{ strings.Title .Title }}</h2></a>
-                    {{ .Summary | truncate 200 }}
+                        <h2>{{ strings.Title .Title }}</h2>
+                        {{ .Summary | truncate 200 }}
                     </span>
-                    <span>
-                    {{ if .Truncated }}
-                    <!-- This <div> includes a read more link, but only if the summary is truncated... -->
-                    <!--<div class="bottom-link">
-                        <a href="{{ .RelPermalink }}">Continue reading…</a>
-                    </div>-->
-                    {{ end }}
-                    </span>
-                </span>
+                </a>
 
             {{ end }}
         </div>

--- a/themes/bean/layouts/partials/head.html
+++ b/themes/bean/layouts/partials/head.html
@@ -12,10 +12,8 @@
     <title>{{ strings.Title $title }} – {{.Site.Params.description}}</title>
     <meta property="og:title" content="{{ $title }}" />
     <meta property="og:description" content="{{.Site.Params.description}}" />
-    {{ $seed := now.Unix }}
-    {{ $css := resources.Get "style.sass" }}
-    {{ $css = $css | css.Sass }}
-    <link rel="stylesheet" type="text/css" href="{{ $css.Permalink }}?{{ printf "%.12s" (md5 $seed) }}">
+    {{ $css := resources.Get "style.sass" | css.Sass | fingerprint }}
+    <link rel="stylesheet" type="text/css" href="{{ $css.Permalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
     <link rel="icon" type="image/png" sizes="32x32" href="{{.Site.BaseURL}}{{ .Site.Params.icon }}">
     <link rel="alternate" type="application/rss+xml" href="{{.Site.BaseURL }}/index.xml" title="{{ .Site.Title }}">
     {{ partial "schema.html" . }}

--- a/themes/bean/layouts/partials/schema.html
+++ b/themes/bean/layouts/partials/schema.html
@@ -1,37 +1,44 @@
-<script type="application/ld+json">
-    {{ if eq .Section "posts" }}
-    {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
-      "name": {{ .Title }},
-      "headline": {{ .Title }},
-      "category": {{ .Params.categories }},
-      {{ with .Resources.GetMatch "cover.*" }}"image": {{ .Permalink | absURL }},{{ end }}
-      "datePublished": {{ .PublishDate }},
-      "dateModified": {{ .Lastmod }},
-      "author": {
-        "@type": "Person",
-        "name": {{ "Tofu Dreams" }}
-      },
-      "mainEntityOfPage": { "@type": "WebPage" },
-       "publisher": {
-        "@type": "Organization",
-        "name": {{ "Tofu Dreams" }},
-        "logo": {
-          "@type": "ImageObject",
-          "url": "https://tofudreams.com/logo.png"
-        }
-      },
-      "description": {{ .Summary | plainify | safeHTML }},
-      "keywords": [{{ range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }}]
-    }
-    {{ end }}
-</script>
+{{ if eq .Section "posts" }}
+{{ $recipe := dict
+    "@context" "https://schema.org"
+    "@type" "Recipe"
+    "name" .Title
+    "headline" .Title
+    "datePublished" (.PublishDate.Format "2006-01-02T15:04:05Z07:00")
+    "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+    "author" (dict "@type" "Person" "name" "Tofu Dreams")
+    "publisher" (dict
+        "@type" "Organization"
+        "name" "Tofu Dreams"
+        "logo" (dict "@type" "ImageObject" "url" "https://tofudreams.com/logo.png")
+    )
+    "mainEntityOfPage" (dict "@type" "WebPage")
+    "description" (.Summary | plainify)
+    "keywords" .Params.tags
+}}
+{{ with .Params.categories }}{{ $recipe = merge $recipe (dict "recipeCategory" (index . 0)) }}{{ end }}
+{{ with .Resources.GetMatch "cover.*" }}{{ $recipe = merge $recipe (dict "image" (.Permalink | absURL)) }}{{ end }}
+{{ with .Params.prepTime }}{{ $recipe = merge $recipe (dict "prepTime" (printf "PT%dM" .)) }}{{ end }}
+{{ with .Params.cookTime }}{{ $recipe = merge $recipe (dict "cookTime" (printf "PT%dM" .)) }}{{ end }}
+{{ if and .Params.prepTime .Params.cookTime }}{{ $recipe = merge $recipe (dict "totalTime" (printf "PT%dM" (add .Params.prepTime .Params.cookTime))) }}{{ end }}
+{{ with .Params.servings }}{{ $recipe = merge $recipe (dict "recipeYield" .) }}{{ end }}
+{{ if .Params.ingredients }}
+    {{ $ingr := slice }}
+    {{ range .Params.ingredients }}{{ if not (strings.HasPrefix . "## ") }}{{ $ingr = $ingr | append . }}{{ end }}{{ end }}
+    {{ $recipe = merge $recipe (dict "recipeIngredient" $ingr) }}
+{{ end }}
+{{ if .Params.steps }}
+    {{ $steps := slice }}
+    {{ range .Params.steps }}{{ $steps = $steps | append (dict "@type" "HowToStep" "text" .) }}{{ end }}
+    {{ $recipe = merge $recipe (dict "recipeInstructions" $steps) }}
+{{ end }}
+<script type="application/ld+json">{{ $recipe | jsonify }}</script>
+{{ end }}
 <script type="application/ld+json">
 {
     "@context": "https://schema.org",
     "@type": "Organization",
     "name": "Tofu Dreams",
-    "url": "https://tofudreams.com",
+    "url": "https://tofudreams.com"
 }
 </script>


### PR DESCRIPTION
- Move ingredients, prepTime, cookTime, servings into YAML front matter for all 46 recipes; body content is now just the intro text
- Update single.html to render a recipe card from params, replacing the old inline <div class="recipe"> + checkbox-list pattern
- Enrich Recipe JSON-LD in schema.html: adds recipeIngredient, prepTime, cookTime, totalTime, recipeYield, recipeInstructions (via dict+jsonify, producing valid JSON); fixes trailing comma in Organization schema
- Fix CSS cache busting in head.html: use Hugo fingerprint (content hash) instead of now.Unix which was busting on every page load
- Replace onclick="location.href=…" span/div cards in index, taxonomy, and sidebar with proper <a> elements; update SASS selectors accordingly
- Add li.ingredient-section style for grouped ingredient headings